### PR TITLE
initial commit for profile-driven ModuleDeployer

### DIFF
--- a/spring-cloud-data-rest/pom.xml
+++ b/spring-cloud-data-rest/pom.xml
@@ -31,8 +31,17 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-data-module-deployer-lattice</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/AdminApplication.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/AdminApplication.java
@@ -18,13 +18,14 @@ package org.springframework.cloud.data.rest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.cloud.data.rest.config.AdminConfiguration;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Mark Fisher
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "org.springframework.cloud.data.rest.controller")
+@Import(AdminConfiguration.class)
 public class AdminApplication {
 
 	public static void main(String[] args) throws InterruptedException {

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/AdminConfiguration.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/AdminConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.config;
+
+import org.springframework.cloud.data.module.deployer.ModuleDeployer;
+import org.springframework.cloud.data.module.deployer.lattice.ReceptorModuleDeployer;
+import org.springframework.cloud.data.module.deployer.local.LocalModuleDeployer;
+import org.springframework.cloud.data.rest.controller.StreamController;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * @author Mark Fisher
+ */
+@Configuration
+public class AdminConfiguration {
+
+	@Bean
+	public StreamController streamController(ModuleDeployer moduleDeployer) {
+		return new StreamController(moduleDeployer);
+	}
+
+	@Bean
+	@Profile("!cloud")
+	public ModuleDeployer moduleDeployer() {
+		return new LocalModuleDeployer();
+	}
+
+	@Configuration
+	@Profile("cloud")
+	protected static class CloudConfig {
+
+		@Bean
+		public ModuleDeployer moduleDeployer() {
+			return new ReceptorModuleDeployer();
+		}
+	}
+
+}

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/StreamController.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/StreamController.java
@@ -23,7 +23,6 @@ import org.springframework.cloud.data.core.ModuleDefinition;
 import org.springframework.cloud.data.core.ModuleDeploymentRequest;
 import org.springframework.cloud.data.core.StreamDefinition;
 import org.springframework.cloud.data.module.deployer.ModuleDeployer;
-import org.springframework.cloud.data.module.deployer.local.LocalModuleDeployer;
 import org.springframework.cloud.data.module.registry.ModuleRegistry;
 import org.springframework.cloud.data.module.registry.StubModuleRegistry;
 import org.springframework.cloud.data.repository.StreamDefinitionRepository;
@@ -46,7 +45,17 @@ public class StreamController {
 
 	private final ModuleRegistry registry = new StubModuleRegistry();
 
-	private final ModuleDeployer deployer = new LocalModuleDeployer();
+	private final ModuleDeployer deployer;
+
+	/**
+	 * Create a StreamController that delegates to the provided {@link ModuleDeployer}.
+	 *
+	 * @param moduleDeployer the deployer this controller will use to deploy stream modules.
+	 */
+	public StreamController(ModuleDeployer moduleDeployer) {
+		Assert.notNull(moduleDeployer, "moduleDeployer must not be null");
+		this.deployer = moduleDeployer;
+	}
 
 	@RequestMapping
 	public String list() {


### PR DESCRIPTION
Currently this will create a ReceptorModuleDeployer bean if the "cloud" profile is active,
a LocalModuleDeployer, otherwise. We will later enhance this to be more fine-grained,
including support for a CloudFoundry ModuleDeployer implementation.