### PR TITLE
switch IllegalState and IllegalArg for Assertions

### DIFF
--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/Assertions.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/Assertions.java
@@ -37,12 +37,12 @@ public class Assertions {
 	 * descriptive message otherwise.
 	 * 
 	 * @return the index of the "pair" that was not {@code null}
-	 * @throws IllegalArgumentException if more than one argument is non null
-	 * @throws IllegalStateException if the method is called with wrong values (e.g. non even number of args)
+	 * @throws IllegalStateException if more than one argument is non null
+	 * @throws IllegalArgumentException if the method is called with invalid values (e.g. non even number of args)
 	 */
 	public static int exactlyOneOf(Object... namesAndValues) {
 		int index = atMostOneOf(namesAndValues);
-		Assert.isTrue(index >= 0, "You must specify exactly one of " + collectNames(namesAndValues));
+		Assert.state(index >= 0, "You must specify exactly one of " + collectNames(namesAndValues));
 		return index;
 	}
 
@@ -52,24 +52,22 @@ public class Assertions {
 	 * message otherwise.
 	 * 
 	 * @return the index of the "pair" that was not {@code null}, or -1 if none was set
-	 * @throws IllegalArgumentException if more than one argument is non null
-	 * @throws IllegalStateException if the method is called with wrong values (e.g. non even number of args)
+	 * @throws IllegalStateException if more than one argument is non null
+	 * @throws IllegalArgumentException if the method is called with invalid values (e.g. non even number of args)
 	 */
 	public static int atMostOneOf(Object... namesAndValues) {
 		int index = -1;
-		Assert.state(namesAndValues.length % 2 == 0,
+		Assert.isTrue(namesAndValues.length % 2 == 0,
 				"Expected even number of arguments: " + Arrays.asList(namesAndValues));
 		for (int i = 0; i < namesAndValues.length / 2; i++) {
-			Assert.state(namesAndValues[i * 2] instanceof String, "Argument at position " + i
+			Assert.isTrue(namesAndValues[i * 2] instanceof String, "Argument at position " + i
 					+ " should be argument name");
 			if (namesAndValues[i * 2 + 1] != null && namesAndValues[i * 2 + 1] != Boolean.FALSE) {
 				if (index != -1) {
-					throw new IllegalArgumentException(String.format("You can't specify both '%s' and '%s'",
+					throw new IllegalStateException(String.format("You cannot specify both '%s' and '%s'",
 							namesAndValues[index * 2], namesAndValues[i * 2]));
 				}
-				else {
-					index = i;
-				}
+				index = i;
 			}
 		}
 		return index;

--- a/spring-cloud-data-shell/src/test/java/org/springframework/cloud/data/shell/command/AssertionsTests.java
+++ b/spring-cloud-data-shell/src/test/java/org/springframework/cloud/data/shell/command/AssertionsTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.shell.command;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author Mark Fisher
+ */
+public class AssertionsTests {
+
+	@Test
+	public void atMostOneWithNone() {
+		Assertions.atMostOneOf("foo", null, "bar", null);
+	}
+
+	@Test
+	public void atMostOneWithOne() {
+		Assertions.atMostOneOf("foo", "x", "bar", null);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void atMostOneWithTwo() {
+		Assertions.atMostOneOf("foo", "x", "bar", "y");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void atMostOneWithOddArgs() {
+		Assertions.atMostOneOf("foo", "x", "bar", null, "oops");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void atMostOneWithNonStringKey() {
+		assertEquals(1, Assertions.atMostOneOf("foo", null, 99, "y"));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void exactlyOneWithNone() {
+		assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", null, "baz", null));
+	}
+
+	@Test
+	public void exactlyOneWithOne() {
+		assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", "y", "baz", null));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void exactlyOneWithTwo() {
+		assertEquals(1, Assertions.exactlyOneOf("foo", "x", "bar", "y", "baz", null));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exactlyOneWithOddArgs() {
+		assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", "y", "oops"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exactlyOneWithNonStringKey() {
+		assertEquals(1, Assertions.exactlyOneOf("foo", null, 99, "y"));
+	}
+}


### PR DESCRIPTION
swapped these two exception types based on the following rationale:
- IllegalArgumentException means that the input is *invalid* and thus we can't even continue with the assertion
- IllegalStateException means the assertion itself failed (the data does not conform to the required state)

also added comprehensive unit tests