### PR TITLE
XD-2398: Adding functionality to parse Task based DSL

### DIFF
--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/TaskDefinition.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/TaskDefinition.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.data.core.parser.TaskDefinitionParser;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.util.Assert;
+
+/**
+ * @author Michael Minella
+ */
+public class TaskDefinition {
+
+	private static final TaskDefinitionParser parser = new TaskDefinitionParser();
+
+	/**
+	 * Name of module.
+	 */
+	private final String taskName;
+
+	/**
+	 * Symbolic taskName of a module. This may be generated to a default
+	 * value or specified in the DSL string.
+	 */
+	private final String task;
+
+	/**
+	 * Parameters for module. This is specific to the type of module - for
+	 * instance an http module would include a port number as a parameter.
+	 */
+	private final Map<String, String> parameters;
+
+
+	/**
+	 * Construct a {@code TaskDefinition}. This constructor is private; use
+	 * {@link TaskDefinition.Builder} or
+	 * {@link TaskDefinition#getInstance(String, String)} to create a new instance.
+	 *
+	 * @param taskName taskName of task
+	 * @param task task to be used
+	 * @param parameters module parameters; may be {@code null}
+	 */
+	private TaskDefinition(String taskName, String task, Map<String, String> parameters) {
+		Assert.notNull(taskName, "taskName must not be null");
+		Assert.notNull(task, "task must not be null");
+		this.taskName = taskName;
+		this.task = task;
+		this.parameters = parameters == null
+				? Collections.<String, String>emptyMap()
+				: Collections.unmodifiableMap(new HashMap<>(parameters));
+	}
+
+	public String getTaskName() {
+		return taskName;
+	}
+
+	public String getTask() {
+		return task;
+	}
+
+	/**
+	 * Return parameters for module. This is specific to the type of module - for
+	 * instance a filejdbc module would contain a file name as a parameter.
+	 *
+	 * @return read-only map of module parameters
+	 */
+	public Map<String, String> getParameters() {
+		return parameters;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this)
+				.append("taskName", this.taskName)
+				.append("task", this.task)
+				.append("parameters", this.parameters).toString();
+	}
+
+	public static TaskDefinition getInstance(String name, String dsl) {
+		return parser.parse(name, dsl);
+	}
+
+
+	/**
+	 * Builder object for {@code TaskDefinition}.
+	 * This object is mutable to allow for flexibility in specifying module
+	 * fields/parameters during parsing.
+	 */
+	public static class Builder {
+
+		/**
+		 * @see TaskDefinition#taskName
+		 */
+		private String taskName;
+
+		/**
+		 * @see TaskDefinition#task
+		 */
+		private String task;
+
+		/**
+		 * @see TaskDefinition#parameters
+		 */
+		private final Map<String, String> parameters = new HashMap<String, String>();
+
+
+		/**
+		 * Set the taskName.
+		 *
+		 * @param taskName of task
+		 * @return this builder object
+		 *
+		 * @see TaskDefinition#taskName
+		 */
+		public Builder setTaskName(String taskName) {
+			this.taskName = taskName;
+			return this;
+		}
+
+		/**
+		 * Set the task.
+		 *
+		 * @param task task to be executed
+		 * @return this builder object
+		 *
+		 * @see TaskDefinition#task
+		 */
+		public Builder setTask(String task) {
+			this.task = task;
+			return this;
+		}
+
+		/**
+		 * Set a module parameter.
+		 *
+		 * @param name parameter taskName
+		 * @param value parameter value
+		 * @return this builder object
+		 *
+		 * @see TaskDefinition#parameters
+		 */
+		public Builder setParameter(String name, String value) {
+			this.parameters.put(name, value);
+			return this;
+		}
+
+		/**
+		 * Add the contents of the provided map to the map of module parameters.
+		 *
+		 * @param parameters module parameters
+		 * @return this builder object
+		 *
+		 * @see TaskDefinition#parameters
+		 */
+		public Builder addParameters(Map<String, String> parameters) {
+			if(parameters != null) {
+				this.parameters.putAll(parameters);
+			}
+			return this;
+		}
+
+		/**
+		 * Return taskName of module.
+		 *
+		 * @return module taskName
+		 */
+		public String getTaskName() {
+			return taskName;
+		}
+
+		/**
+		 * Return symbolic taskName of a module. This will be explicitly specified in
+		 * the DSL string.
+		 *
+		 * @return task task module
+		 */
+		public String getTask() {
+			return task;
+		}
+
+		/**
+		 * Return parameters for task. This is specific to the type of task -
+		 * for instance an filejdbc task would include a file name as a parameter.
+		 * <br />
+		 * Note that the contents of this map are <b>mutable</b>.
+		 *
+		 * @return map of module parameters
+		 */
+		public Map<String, String> getParameters() {
+			return parameters;
+		}
+
+		/**
+		 * Return a new instance of {@link TaskDefinition}.
+		 *
+		 * @return new instance of {@code TaskDefinition}
+		 */
+		public TaskDefinition build() {
+			if (this.task == null) {
+				this.task = this.taskName;
+			}
+			return new TaskDefinition(this.taskName, this.task, this.parameters);
+		}
+	}
+}

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/CheckPointedTaskDefinitionException.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/CheckPointedTaskDefinitionException.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.data.core.dsl;
 import java.util.List;
 
 /**
- * An extension of StreamDefinitionException that remembers the point up
+ * An extension of TaskDefinitionException that remembers the point up
  * to which parsing went OK (signaled by a '*' in the dumped message).
  *
  * @author Eric Bottard

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/CheckPointedTaskDefinitionException.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/CheckPointedTaskDefinitionException.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.core.dsl;
+
+import java.util.List;
+
+/**
+ * An extension of StreamDefinitionException that remembers the point up
+ * to which parsing went OK (signaled by a '*' in the dumped message).
+ *
+ * @author Eric Bottard
+ */
+@SuppressWarnings("serial")
+public class CheckPointedTaskDefinitionException extends TaskDefinitionException {
+
+	private int checkpointPointer = -1;
+
+	private List<Token> tokens;
+
+	private int tokenPointer;
+
+	/**
+	 * Construct a new exception
+	 * @param expressionString the raw, untokenized text that was being parsed
+	 * @param textPosition the text offset where the error occurs
+	 * @param tokenPointer the token-index of token where the error occurred
+	 * @param checkpointPointer the token-index of the last known good token
+	 * @param tokens the list of tokens that make up expressionString
+	 * @param message the error message
+	 * @param inserts variables that may be inserted in the error message
+	 */
+	public CheckPointedTaskDefinitionException(String expressionString, int textPosition, int tokenPointer,
+			int checkpointPointer, List<Token> tokens, DSLMessage message, Object... inserts) {
+		super(expressionString, textPosition, message, inserts);
+		this.tokenPointer = tokenPointer;
+		this.checkpointPointer = checkpointPointer;
+		this.tokens = tokens;
+	}
+
+
+	/**
+	 * @return a formatted message with inserts applied.
+	 */
+	@Override
+	public String getMessage() {
+		StringBuilder s = new StringBuilder();
+		if (message != null) {
+			s.append(message.formatMessage(position, inserts));
+		}
+		else {
+			s.append(super.getMessage());
+		}
+		if (expressionString != null && expressionString.length() > 0) {
+			s.append("\n").append(expressionString).append("\n");
+		}
+		int offset = position;
+		if (checkpointPointer > 0 && offset >= 0) {
+			int checkpointPosition = getCheckpointPosition();
+			offset -= checkpointPosition;
+			for (int i = 0; i < checkpointPosition; i++) {
+				s.append(' ');
+			}
+			s.append("*");
+			offset--; // account for the '*'
+		}
+		if (offset >= 0) {
+			for (int i = 0; i < offset; i++) {
+				s.append(' ');
+			}
+			s.append("^\n");
+		}
+		return s.toString();
+	}
+
+	public int getCheckpointPosition() {
+		return checkpointPointer == 0 ? 0 : tokens.get(checkpointPointer - 1).endPos;
+	}
+
+	/**
+	 * Return the parsed expression until the last known, well formed position. Attempting to re-parse that expression
+	 * is guaranteed to not fail.
+	 */
+	public String getExpressionStringUntilCheckpoint() {
+		return expressionString.substring(0, getCheckpointPosition());
+	}
+
+	public int getCheckpointPointer() {
+		return checkpointPointer;
+	}
+
+
+	public List<Token> getTokens() {
+		return tokens;
+	}
+
+
+	public int getTokenPointer() {
+		return tokenPointer;
+	}
+
+}

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/DSLMessage.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/DSLMessage.java
@@ -59,6 +59,7 @@ public enum DSLMessage {
 	EXPECTED_CHANNEL_QUALIFIER(ERROR, 120, "expected channel reference '':<channel>'' but found ''{0}''"), //
 	EXPECTED_CHANNEL_NAME(ERROR, 121, "expected channel name but found ''{0}''"), //
 	ILLEGAL_STREAM_NAME(ERROR, 122, "illegal name for a stream ''{0}''"), //
+	ILLEGAL_TASK_NAME(ERROR, 122, "illegal name for a task ''{0}''"), //
 	MISSING_VALUE_FOR_VARIABLE(ERROR, 125, "no value specified for variable ''{0}'' when using substream"), //
 	VARIABLE_NOT_TERMINATED(ERROR, 126, "unable to find variable terminator ''}'' in argument ''{0}''"), //
 	AMBIGUOUS_MODULE_NAME(ERROR,

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/DSLMessage.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/DSLMessage.java
@@ -59,7 +59,7 @@ public enum DSLMessage {
 	EXPECTED_CHANNEL_QUALIFIER(ERROR, 120, "expected channel reference '':<channel>'' but found ''{0}''"), //
 	EXPECTED_CHANNEL_NAME(ERROR, 121, "expected channel name but found ''{0}''"), //
 	ILLEGAL_STREAM_NAME(ERROR, 122, "illegal name for a stream ''{0}''"), //
-	ILLEGAL_TASK_NAME(ERROR, 122, "illegal name for a task ''{0}''"), //
+	ILLEGAL_TASK_NAME(ERROR, 123, "illegal name for a task ''{0}''"), //
 	MISSING_VALUE_FOR_VARIABLE(ERROR, 125, "no value specified for variable ''{0}'' when using substream"), //
 	VARIABLE_NOT_TERMINATED(ERROR, 126, "unable to find variable terminator ''}'' in argument ''{0}''"), //
 	AMBIGUOUS_MODULE_NAME(ERROR,

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/TaskDefinitionException.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/TaskDefinitionException.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.core.dsl;
+
+/**
+ * Root exception for DSL parsing related exceptions. Rather than holding a
+ * hard coded string indicating the problem, it records a message key and
+ * the inserts for the message. See {@link DSLMessage} for the list of all
+ * possible messages that can occur.
+ *
+ * @author Andy Clement
+ */
+@SuppressWarnings("serial")
+public class TaskDefinitionException extends RuntimeException {
+
+	protected String expressionString;
+
+	protected int position; // -1 if not known - but should be known in all reasonable cases
+
+	protected DSLMessage message;
+
+	protected Object[] inserts;
+
+	public TaskDefinitionException(String expressionString, int position, DSLMessage message, Object... inserts) {
+		super(message.formatMessage(position, inserts));
+		this.position = position;
+		this.message = message;
+		this.inserts = inserts;
+		this.expressionString = expressionString;
+	}
+
+	/**
+	 * @return a formatted message with inserts applied
+	 */
+	@Override
+	public String getMessage() {
+		StringBuilder s = new StringBuilder();
+		if (message != null) {
+			s.append(message.formatMessage(position, inserts));
+		}
+		else {
+			s.append(super.getMessage());
+		}
+		if (expressionString != null && expressionString.length() > 0) {
+			s.append("\n").append(expressionString).append("\n");
+		}
+		if (position >= 0) {
+			for (int i = 0; i < position; i++) {
+				s.append(' ');
+			}
+			s.append("^\n");
+		}
+		return s.toString();
+	}
+
+	/**
+	 * @return the message code
+	 */
+	public DSLMessage getMessageCode() {
+		return this.message;
+	}
+
+	/**
+	 * @return the message inserts
+	 */
+	public Object[] getInserts() {
+		return inserts;
+	}
+
+	/**
+	 * @return the dsl expression text
+	 */
+	public final String getExpressionString() {
+		return this.expressionString;
+	}
+
+	/**
+	 * @return location of the error in the expression text
+	 */
+	public final int getPosition() {
+		return position;
+	}
+
+}

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/TaskDslParser.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/TaskDslParser.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.core.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Michael Minella
+ */
+public class TaskDslParser {
+
+	private String expressionString;
+
+	private List<Token> tokenStream;
+
+	private int tokenStreamLength;
+
+	private int tokenStreamPointer; // Current location in the token stream when
+
+	// processing tokens
+
+	private int lastGoodPoint;
+
+	/**
+	 * Parse a task definition without supplying the task name up front.
+	 * The task name may be embedded in the definition.
+	 * For example: <code>myTask = filejdbc</code>
+	 *
+	 * @return the AST for the parsed stream
+	 */
+	public ModuleNode parse(String stream) {
+		return parse(null, stream);
+	}
+
+	/**
+	 * Parse a task definition.
+	 *
+	 * @return the AST for the parsed task
+	 * @throws TaskDefinitionException
+	 */
+	public ModuleNode parse(String name, String task) {
+		this.expressionString = task;
+		Tokenizer tokenizer;
+		try {
+			tokenizer = new Tokenizer(expressionString);
+		}
+		catch (StreamDefinitionException e) {
+			throw new TaskDefinitionException(e.getExpressionString(), e.getPosition(), e.getMessageCode());
+		}
+
+		tokenStream = tokenizer.getTokens();
+		tokenStreamLength = tokenStream.size();
+		tokenStreamPointer = 0;
+		ModuleNode ast = eatModule();
+
+		// Check the task name, however it was specified
+		if (ast.getName() != null && !isValidTaskName(ast.getName())) {
+			throw new TaskDefinitionException(ast.getName(), 0, DSLMessage.ILLEGAL_TASK_NAME, ast.getName());
+		}
+		if (name != null && !isValidTaskName(name)) {
+			throw new TaskDefinitionException(name, 0, DSLMessage.ILLEGAL_TASK_NAME, name);
+		}
+		if (moreTokens()) {
+			throw new TaskDefinitionException(this.expressionString, peekToken().startPos, DSLMessage.MORE_INPUT,
+					toString(nextToken()));
+		}
+
+		return ast;
+	}
+
+	// module: [label':']? identifier (moduleArguments)*
+	private ModuleNode eatModule() {
+		Token label = null;
+		Token name = nextToken();
+		if (!name.isKind(TokenKind.IDENTIFIER)) {
+			raiseException(name.startPos, DSLMessage.EXPECTED_MODULENAME, name.data != null ? name.data
+					: new String(name.getKind().tokenChars));
+		}
+		if (peekToken(TokenKind.COLON)) {
+			if (!isNextTokenAdjacent()) {
+				raiseException(peekToken().startPos, DSLMessage.NO_WHITESPACE_BETWEEN_LABEL_NAME_AND_COLON);
+			}
+			nextToken(); // swallow colon
+			label = name;
+			name = eatToken(TokenKind.IDENTIFIER);
+		}
+		Token moduleName = name;
+		checkpoint();
+		ArgumentNode[] args = maybeEatModuleArgs();
+		int startpos = label != null ? label.startPos : moduleName.startPos;
+		return new ModuleNode(toLabelNode(label), moduleName.data, startpos, moduleName.endPos, args);
+	}
+
+	private LabelNode toLabelNode(Token label) {
+		if (label == null) {
+			return null;
+		}
+		return new LabelNode(label.data, label.startPos, label.endPos);
+	}
+
+	// moduleArguments : DOUBLE_MINUS identifier(name) EQUALS identifier(value)
+	private ArgumentNode[] maybeEatModuleArgs() {
+		List<ArgumentNode> args = null;
+		if (peekToken(TokenKind.DOUBLE_MINUS) && isNextTokenAdjacent()) {
+			raiseException(peekToken().startPos, DSLMessage.EXPECTED_WHITESPACE_AFTER_MODULE_BEFORE_ARGUMENT);
+		}
+		while (peekToken(TokenKind.DOUBLE_MINUS)) {
+			Token dashDash = nextToken(); // skip the '--'
+			if (peekToken(TokenKind.IDENTIFIER) && !isNextTokenAdjacent()) {
+				raiseException(peekToken().startPos, DSLMessage.NO_WHITESPACE_BEFORE_ARG_NAME);
+			}
+			List<Token> argNameComponents = eatDottedName();
+			if (peekToken(TokenKind.EQUALS) && !isNextTokenAdjacent()) {
+				raiseException(peekToken().startPos, DSLMessage.NO_WHITESPACE_BEFORE_ARG_EQUALS);
+			}
+			eatToken(TokenKind.EQUALS);
+			if (peekToken(TokenKind.IDENTIFIER) && !isNextTokenAdjacent()) {
+				raiseException(peekToken().startPos, DSLMessage.NO_WHITESPACE_BEFORE_ARG_VALUE);
+			}
+			// Process argument value:
+			Token t = peekToken();
+			String argValue = eatArgValue();
+			checkpoint();
+			if (args == null) {
+				args = new ArrayList<ArgumentNode>();
+			}
+			args.add(new ArgumentNode(data(argNameComponents), argValue, dashDash.startPos, t.endPos));
+		}
+		return args == null ? null : args.toArray(new ArgumentNode[args.size()]);
+	}
+
+	// argValue: identifier | literal_string
+	private String eatArgValue() {
+		Token t = nextToken();
+		String argValue = null;
+		if (t.getKind() == TokenKind.IDENTIFIER) {
+			argValue = t.data;
+		}
+		else if (t.getKind() == TokenKind.LITERAL_STRING) {
+			String quotesUsed = t.data.substring(0, 1);
+			argValue = t.data.substring(1, t.data.length() - 1).replace(quotesUsed+quotesUsed, quotesUsed);
+		}
+		else {
+			raiseException(t.startPos, DSLMessage.EXPECTED_ARGUMENT_VALUE, t.data);
+		}
+		return argValue;
+	}
+
+	private Token eatToken(TokenKind expectedKind) {
+		Token t = nextToken();
+		if (t == null) {
+			raiseException(expressionString.length(), DSLMessage.OOD);
+		}
+		if (t.kind != expectedKind) {
+			raiseException(t.startPos, DSLMessage.NOT_EXPECTED_TOKEN, expectedKind.toString().toLowerCase(),
+					t.getKind().toString().toLowerCase() + (t.data == null ? "" : "(" + t.data + ")"));
+		}
+		return t;
+	}
+
+	private boolean peekToken(TokenKind desiredTokenKind) {
+		return peekToken(desiredTokenKind, false);
+	}
+
+	private boolean lookAhead(int distance, TokenKind desiredTokenKind) {
+		if ((tokenStreamPointer + distance) >= tokenStream.size()) {
+			return false;
+		}
+		Token t = tokenStream.get(tokenStreamPointer + distance);
+		if (t.kind == desiredTokenKind) {
+			return true;
+		}
+		return false;
+	}
+
+	private List<Token> eatDottedName() {
+		return eatDottedName(DSLMessage.NOT_EXPECTED_TOKEN);
+	}
+
+	/**
+	 * Consumes and returns (identifier [DOT identifier]*) as long as they're adjacent.
+	 *
+	 * @param error the kind of error to report if input is ill-formed
+	 */
+	private List<Token> eatDottedName(DSLMessage error) {
+		List<Token> result = new ArrayList<Token>(3);
+		Token name = nextToken();
+		if (!name.isKind(TokenKind.IDENTIFIER)) {
+			raiseException(name.startPos, error, name.data != null ? name.data
+					: new String(name.getKind().tokenChars));
+		}
+		result.add(name);
+		while (peekToken(TokenKind.DOT)) {
+			if (!isNextTokenAdjacent()) {
+				raiseException(peekToken().startPos, DSLMessage.NO_WHITESPACE_IN_DOTTED_NAME);
+			}
+			result.add(nextToken()); // consume dot
+			if (peekToken(TokenKind.IDENTIFIER) && !isNextTokenAdjacent()) {
+				raiseException(peekToken().startPos, DSLMessage.NO_WHITESPACE_IN_DOTTED_NAME);
+			}
+			result.add(eatToken(TokenKind.IDENTIFIER));
+		}
+		return result;
+	}
+
+	/**
+	 * Verify the supplied name is a valid task name. Valid stream names must follow the same rules as java
+	 * identifiers, with the additional option to use a hyphen ('-') after the first character.
+	 *
+	 * @param taskname the name to validate
+	 * @return true if name is valid
+	 */
+	public static boolean isValidTaskName(String taskname) {
+		if (taskname.length() == 0) {
+			return false;
+		}
+		if (!Character.isJavaIdentifierStart(taskname.charAt(0))) {
+			return false;
+		}
+		for (int i = 1, max = taskname.length(); i < max; i++) {
+			char ch = taskname.charAt(i);
+			if (!(Character.isJavaIdentifierPart(ch) || ch == '-')) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Return the concatenation of the data of many tokens.
+	 */
+	private String data(Iterable<Token> many) {
+		StringBuilder result = new StringBuilder();
+		for (Token t : many) {
+			if (t.getKind().hasPayload()) {
+				result.append(t.data);
+			}
+			else {
+				result.append(t.getKind().tokenChars);
+			}
+		}
+		return result.toString();
+	}
+
+	private boolean peekToken(TokenKind desiredTokenKind, boolean consumeIfMatched) {
+		if (!moreTokens()) {
+			return false;
+		}
+		Token t = peekToken();
+		if (t.kind == desiredTokenKind) {
+			if (consumeIfMatched) {
+				tokenStreamPointer++;
+			}
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	private boolean moreTokens() {
+		return tokenStreamPointer < tokenStream.size();
+	}
+
+	private Token nextToken() {
+		if (tokenStreamPointer >= tokenStreamLength) {
+			raiseException(expressionString.length(), DSLMessage.OOD);
+		}
+		return tokenStream.get(tokenStreamPointer++);
+	}
+
+	private boolean isNextTokenAdjacent() {
+		if (tokenStreamPointer >= tokenStreamLength) {
+			return false;
+		}
+		Token last = tokenStream.get(tokenStreamPointer - 1);
+		Token next = tokenStream.get(tokenStreamPointer);
+		return next.startPos == last.endPos;
+	}
+
+	private Token peekToken() {
+		if (tokenStreamPointer >= tokenStreamLength) {
+			return null;
+		}
+		return tokenStream.get(tokenStreamPointer);
+	}
+
+	private void raiseException(int pos, DSLMessage message, Object... inserts) {
+		throw new CheckPointedTaskDefinitionException(expressionString, pos, tokenStreamPointer, lastGoodPoint,
+				tokenStream, message, inserts);
+	}
+
+	private void checkpoint() {
+		lastGoodPoint = tokenStreamPointer;
+	}
+
+	private String toString(Token t) {
+		if (t.getKind().hasPayload()) {
+			return t.stringValue();
+		}
+		else {
+			return new String(t.kind.getTokenChars());
+		}
+	}
+
+}

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/parser/TaskDefinitionParser.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/parser/TaskDefinitionParser.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.core.parser;
+
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.cloud.data.core.dsl.ArgumentNode;
+import org.springframework.cloud.data.core.dsl.ModuleNode;
+import org.springframework.cloud.data.core.dsl.TaskDslParser;
+
+/**
+ * @author Michael Minella
+ */
+public class TaskDefinitionParser {
+
+	/**
+	 * Parse the provided task DSL task and return a
+	 * {@link TaskDefinition task definition} that define
+	 * the task.
+	 *
+	 * @param name  task name
+	 * @param dsl   task DSL text
+	 * @return task definition
+	 */
+	public TaskDefinition parse(String name, String dsl) {
+		TaskDslParser parser = new TaskDslParser();
+		return buildModuleDefinitions(name, parser.parse(name, dsl));
+	}
+
+	/**
+	 * Build TaskDefinition out of a parsed ModuleNode.
+	 *
+	 * @param name the name of the definition unit
+	 * @param taskNode the AST construct representing the definition
+	 */
+	private TaskDefinition buildModuleDefinitions(String name, ModuleNode taskNode) {
+		TaskDefinition.Builder builder =
+					new TaskDefinition.Builder()
+						.setTaskName(name)
+						.setTask(taskNode.getLabelName());
+		if (taskNode.hasArguments()) {
+			ArgumentNode[] arguments = taskNode.getArguments();
+			for (ArgumentNode argument : arguments) {
+				builder.setParameter(argument.getName(), argument.getValue());
+			}
+		}
+
+		return builder.build();
+	}
+}

--- a/spring-cloud-data-core/src/test/java/org/springframework/cloud/data/core/dsl/TaskConfigParserTests.java
+++ b/spring-cloud-data-core/src/test/java/org/springframework/cloud/data/core/dsl/TaskConfigParserTests.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.core.dsl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.Properties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.cloud.data.core.parser.TaskDefinitionParser;
+
+/**
+ * Parse tasks and verify either the correct abstract syntax tree is produced or the current exception comes out.
+ *
+ * @author Andy Clement
+ * @author David Turanski
+ * @author Michael Minella
+ */
+public class TaskConfigParserTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private ModuleNode mn;
+
+	@Test
+	public void oneModule() {
+		mn = parse("foo");
+		assertEquals("foo", mn.getName());
+		assertEquals(0, mn.getArguments().length);
+		assertEquals(0, mn.startPos);
+		assertEquals(3, mn.endPos);
+	}
+
+	@Test
+	public void hyphenatedModuleName() {
+		mn = parse("gemfire-cq");
+		assertEquals("(ModuleNode:gemfire-cq:0>10)", mn.stringify(true));
+	}
+
+	// Modules can take parameters
+	@Test
+	public void oneModuleWithParam() {
+		ModuleNode ast = parse("foo --name=value");
+		assertEquals("(ModuleNode:foo --name=value:0>16)", ast.stringify(true));
+	}
+
+	// Modules can take two parameters
+	@Test
+	public void oneModuleWithTwoParams() {
+		ModuleNode mn = parse("foo --name=value --x=y");
+
+		assertEquals("foo", mn.getName());
+		ArgumentNode[] args = mn.getArguments();
+		assertNotNull(args);
+		assertEquals(2, args.length);
+		assertEquals("name", args[0].getName());
+		assertEquals("value", args[0].getValue());
+		assertEquals("x", args[1].getName());
+		assertEquals("y", args[1].getValue());
+
+		assertEquals("(ModuleNode:foo --name=value --x=y:0>22)", mn.stringify(true));
+	}
+
+	@Test
+	public void testParameters() {
+		String module = "gemfire-cq --query='Select * from /Stocks where symbol=''VMW''' --regionName=foo --foo=bar";
+		ModuleNode gemfireModule = parse(module);
+		Properties parameters = gemfireModule.getArgumentsAsProperties();
+		assertEquals(3, parameters.size());
+		assertEquals("Select * from /Stocks where symbol='VMW'", parameters.get("query"));
+		assertEquals("foo", parameters.get("regionName"));
+		assertEquals("bar", parameters.get("foo"));
+
+		module = "test";
+		parameters = parse(module).getArgumentsAsProperties();
+		assertEquals(0, parameters.size());
+
+		module = "foo --x=1 --y=two ";
+		parameters = parse(module).getArgumentsAsProperties();
+		assertEquals(2, parameters.size());
+		assertEquals("1", parameters.get("x"));
+		assertEquals("two", parameters.get("y"));
+
+		module = "foo --x=1a2b --y=two ";
+		parameters = parse(module).getArgumentsAsProperties();
+		assertEquals(2, parameters.size());
+		assertEquals("1a2b", parameters.get("x"));
+		assertEquals("two", parameters.get("y"));
+
+		module = "foo --x=2";
+		parameters = parse(module).getArgumentsAsProperties();
+		assertEquals(1, parameters.size());
+		assertEquals("2", parameters.get("x"));
+
+		module = "--foo = bar";
+		try {
+			parse(module);
+			fail(module + " is invalid. Should throw exception");
+		}
+		catch (Exception e) {
+			// success
+		}
+	}
+
+	@Test
+	public void testInvalidModules() {
+		String config = "foo--x=13";
+		TaskDefinitionParser parser = new TaskDefinitionParser();
+		try {
+			parser.parse("t", config);
+			fail(config + " is invalid. Should throw exception");
+		}
+		catch (Exception e) {
+			// success
+		}
+	}
+
+	@Test
+	public void expressions_xd159() {
+		ModuleNode mn = parse("transform --expression=--payload");
+		Properties props = mn.getArgumentsAsProperties();
+		assertEquals("--payload", props.get("expression"));
+	}
+
+	@Test
+	public void expressions_xd159_2() {
+		// need quotes around an argument value with a space in it
+		checkForParseError("transform --expression=new StringBuilder(payload).reverse()",
+				DSLMessage.UNEXPECTED_DATA, 40);
+	}
+
+	@Test
+	public void ensureTaskNamesValid_xd1344() {
+		// Similar rules to a java identifier but also allowed '-' after the first char
+		checkForIllegalTaskName("foo.bar", "task");
+		checkForIllegalTaskName("-bar", "task");
+		checkForIllegalTaskName(".bar", "task");
+		checkForIllegalTaskName("foo-.-bar", "task");
+		checkForIllegalTaskName("0foobar", "task");
+		checkForIllegalTaskName("foo%bar", "task");
+		parse("foo-bar", "task");
+		parse("foo_bar", "task");
+	}
+
+	@Test
+	public void expressions_xd159_3() {
+		ModuleNode mn = parse("transform --expression='new StringBuilder(payload).reverse()'");
+		Properties props = mn.getArgumentsAsProperties();
+		assertEquals("new StringBuilder(payload).reverse()", props.get("expression"));
+	}
+
+	@Test
+	public void expressions_xd159_4() {
+		ModuleNode mn = parse("transform --expression=\"'Hello, world!'\"");
+		Properties props = mn.getArgumentsAsProperties();
+		assertEquals("'Hello, world!'", props.get("expression"));
+		mn = parse("transform --expression='''Hello, world!'''");
+		props = mn.getArgumentsAsProperties();
+		assertEquals("'Hello, world!'", props.get("expression"));
+		// Prior to the change for XD-1613, this error should point to the comma:
+		// checkForParseError("foo |  transform --expression=''Hello, world!'' | bar", DSLMessage.UNEXPECTED_DATA,
+		// 37);
+		// but now it points to the !
+		checkForParseError("transform --expression=''Hello, world!''", DSLMessage.UNEXPECTED_DATA, 37);
+	}
+
+	@Test
+	public void expressions_gh1() {
+		ModuleNode mn = parse("filter --expression=\"payload == 'foo'\"");
+		Properties props = mn.getArgumentsAsProperties();
+		assertEquals("payload == 'foo'", props.get("expression"));
+	}
+
+	@Test
+	public void expressions_gh1_2() {
+		ModuleNode mn = parse("filter --expression='new Foo()'");
+		Properties props = mn.getArgumentsAsProperties();
+		assertEquals("new Foo()", props.get("expression"));
+	}
+
+	@Test
+	public void errorCases01() {
+		checkForParseError(".", DSLMessage.EXPECTED_MODULENAME, 0, ".");
+		checkForParseError(";", DSLMessage.EXPECTED_MODULENAME, 0, ";");
+	}
+
+	@Test
+	public void errorCases04() {
+		checkForParseError("foo bar=yyy", DSLMessage.MORE_INPUT, 4, "bar");
+		checkForParseError("foo bar", DSLMessage.MORE_INPUT, 4, "bar");
+	}
+
+	@Test
+	public void errorCases05() {
+		checkForParseError("foo --", DSLMessage.OOD, 6);
+		checkForParseError("foo --bar", DSLMessage.OOD, 9);
+		checkForParseError("foo --bar=", DSLMessage.OOD, 10);
+	}
+
+	@Test
+	public void errorCases06() {
+		checkForParseError("|", DSLMessage.EXPECTED_MODULENAME, 0);
+	}
+
+	// Parameters must be constructed via adjacent tokens
+	@Test
+	public void needAdjacentTokensForParameters() {
+		checkForParseError("foo -- name=value", DSLMessage.NO_WHITESPACE_BEFORE_ARG_NAME, 7);
+		checkForParseError("foo --name =value", DSLMessage.NO_WHITESPACE_BEFORE_ARG_EQUALS, 11);
+		checkForParseError("foo --name= value", DSLMessage.NO_WHITESPACE_BEFORE_ARG_VALUE, 12);
+	}
+
+	// ---
+
+	@Test
+	public void testComposedOptionNameErros() {
+		checkForParseError("foo --name.=value", DSLMessage.NOT_EXPECTED_TOKEN, 11);
+		checkForParseError("foo --name .sub=value", DSLMessage.NO_WHITESPACE_IN_DOTTED_NAME, 11);
+		checkForParseError("foo --name. sub=value", DSLMessage.NO_WHITESPACE_IN_DOTTED_NAME, 12);
+	}
+
+	@Test
+	public void testXD2416() {
+		ModuleNode mn = parse("transform --expression='payload.replace(\"abc\", \"\")'");
+		assertEquals(mn.getArgumentsAsProperties().get("expression"), "payload.replace(\"abc\", \"\")");
+
+		mn = parse("transform --expression='payload.replace(\"abc\", '''')'");
+		assertEquals(mn.getArgumentsAsProperties().get("expression"), "payload.replace(\"abc\", '')");
+	}
+
+	private TaskDslParser getParser() {
+		return new TaskDslParser();
+	}
+
+	ModuleNode parse(String taskDefinition) {
+		return getParser().parse(taskDefinition);
+	}
+
+	ModuleNode parse(String taskName, String taskDefinition) {
+		return getParser().parse(taskName, taskDefinition);
+	}
+
+	private void checkForIllegalTaskName(String taskName, String taskDef) {
+		try {
+			ModuleNode sn = parse(taskName, taskDef);
+			fail("expected to fail but parsed " + sn.stringify());
+		}
+		catch (TaskDefinitionException e) {
+			assertEquals(DSLMessage.ILLEGAL_TASK_NAME, e.getMessageCode());
+			assertEquals(0, e.getPosition());
+			assertEquals(taskName, e.getInserts()[0]);
+		}
+	}
+
+	private void checkForParseError(String task, DSLMessage msg, int pos, Object... inserts) {
+		try {
+			ModuleNode sn = parse(task);
+			fail("expected to fail but parsed " + sn.stringify());
+		}
+		catch (TaskDefinitionException e) {
+			assertEquals(msg, e.getMessageCode());
+			assertEquals(pos, e.getPosition());
+			if (inserts != null) {
+				for (int i = 0; i < inserts.length; i++) {
+					assertEquals(inserts[i], e.getInserts()[i]);
+				}
+			}
+		}
+	}
+}

--- a/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/TaskDefinitionResource.java
+++ b/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/TaskDefinitionResource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.rest.resource;
+
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * A HATEOAS representation of a {@link TaskDefinition}.
+ *
+ * @author Michael Minella
+ */
+public class TaskDefinitionResource extends ResourceSupport {
+
+	private String name;
+
+	private String dslText;
+
+	public TaskDefinitionResource() {
+	}
+
+	public TaskDefinitionResource(String name, String dslText) {
+		this.name = name;
+		this.dslText = dslText;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDslText() {
+		return dslText;
+	}
+
+	public static class Page extends PagedResources<TaskDefinitionResource>{}
+}

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/AdminConfiguration.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/AdminConfiguration.java
@@ -27,7 +27,9 @@ import org.springframework.cloud.data.module.deployer.local.LocalModuleDeployer;
 import org.springframework.cloud.data.module.registry.ModuleRegistry;
 import org.springframework.cloud.data.module.registry.StubModuleRegistry;
 import org.springframework.cloud.data.rest.repository.InMemoryStreamDefinitionRepository;
+import org.springframework.cloud.data.rest.repository.InMemoryTaskDefinitionRepository;
 import org.springframework.cloud.data.rest.repository.StreamDefinitionRepository;
+import org.springframework.cloud.data.rest.repository.TaskDefinitionRepository;
 import org.springframework.cloud.stream.module.launcher.ModuleLauncher;
 import org.springframework.cloud.stream.module.launcher.ModuleLauncherConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -60,6 +62,11 @@ public class AdminConfiguration {
 	@Bean
 	public StreamDefinitionRepository streamDefinitionRepository() {
 		return new InMemoryStreamDefinitionRepository();
+	}
+
+	@Bean
+	public TaskDefinitionRepository taskDefinitionRepository() {
+		return new InMemoryTaskDefinitionRepository();
 	}
 
 	@Bean

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/AdminController.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/AdminController.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.data.rest.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.data.rest.resource.StreamDefinitionResource;
+import org.springframework.cloud.data.rest.resource.TaskDefinitionResource;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -58,6 +59,7 @@ public class AdminController {
 	public ResourceSupport info() {
 		ResourceSupport resourceSupport = new ResourceSupport();
 		resourceSupport.add(entityLinks.linkFor(StreamDefinitionResource.class).withRel("streams"));
+		resourceSupport.add(entityLinks.linkFor(TaskDefinitionResource.class).withRel("tasks"));
 		return resourceSupport;
 	}
 

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/TaskController.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/TaskController.java
@@ -75,13 +75,14 @@ public class TaskController {
 		}
 
 		@Override
-		public TaskDefinitionResource toResource(TaskDefinition stream) {
-			return createResourceWithId(stream.getTaskName(), stream);
+		public TaskDefinitionResource toResource(TaskDefinition taskDefinition) {
+			return createResourceWithId(taskDefinition.getTaskName(), taskDefinition);
 		}
 
 		@Override
-		public TaskDefinitionResource instantiateResource(TaskDefinition entity) {
-			return new TaskDefinitionResource(entity.getTaskName(), entity.getTaskName());
+		public TaskDefinitionResource instantiateResource(TaskDefinition taskDefinition) {
+			return new TaskDefinitionResource(taskDefinition.getTaskName(),
+					taskDefinition.getTask());
 		}
 	}
 }

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/TaskController.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/TaskController.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.rest.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.cloud.data.rest.repository.TaskDefinitionRepository;
+import org.springframework.cloud.data.rest.resource.TaskDefinitionResource;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Michael Minella
+ */
+@RestController
+@RequestMapping("/tasks")
+@ExposesResourceFor(TaskDefinitionResource.class)
+public class TaskController {
+
+	private final Assembler taskAssembler = new Assembler();
+
+	@Autowired
+	private TaskDefinitionRepository repository;
+
+	@RequestMapping(value = "/", method = RequestMethod.POST)
+	public void save(@RequestParam("name") String name,
+			@RequestParam("definition") String dsl) {
+		repository.save(TaskDefinition.getInstance(name, dsl));
+	}
+
+	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public void destroyTask(@PathVariable("name") String name) {
+		repository.delete(name);
+	}
+
+	@RequestMapping(value="/definitions", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public PagedResources<TaskDefinitionResource> list(Pageable pageable,
+			PagedResourcesAssembler<TaskDefinition> assembler) {
+		return assembler.toResource(repository.findAll(pageable), taskAssembler);
+	}
+
+	/**
+	 * {@link org.springframework.hateoas.ResourceAssembler} implementation
+	 * that converts {@link TaskDefinition}s to {@link TaskDefinitionResource}s.
+	 */
+	class Assembler extends ResourceAssemblerSupport<TaskDefinition, TaskDefinitionResource> {
+
+		public Assembler() {
+			super(TaskController.class, TaskDefinitionResource.class);
+		}
+
+		@Override
+		public TaskDefinitionResource toResource(TaskDefinition stream) {
+			return createResourceWithId(stream.getTaskName(), stream);
+		}
+
+		@Override
+		public TaskDefinitionResource instantiateResource(TaskDefinition entity) {
+			return new TaskDefinitionResource(entity.getTaskName(), entity.getTaskName());
+		}
+	}
+}

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/repository/DuplicateTaskException.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/repository/DuplicateTaskException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.rest.repository;
+
+/**
+ * @author Michael Minella
+ */
+public class DuplicateTaskException extends RuntimeException {
+
+	public DuplicateTaskException() {
+		super();
+	}
+
+	public DuplicateTaskException(String message) {
+		super(message);
+	}
+}

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/repository/InMemoryTaskDefinitionRepository.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/repository/InMemoryTaskDefinitionRepository.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.repository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * In-memory implementation of {@link TaskDefinitionRepository}.
+ *
+ * @author Michael Minella
+ * @author Mark Fisher
+ * @author Patrick Peralta
+ */
+public class InMemoryTaskDefinitionRepository implements TaskDefinitionRepository {
+
+	private final Map<String, TaskDefinition> definitions = new ConcurrentHashMap<>();
+
+	@Override
+	public Iterable<TaskDefinition> findAll(Sort sort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Page<TaskDefinition> findAll(Pageable pageable) {
+		List<TaskDefinition> results = new ArrayList<>(definitions.values());
+		return new PageImpl<>(results, pageable, results.size());
+	}
+
+	@Override
+	public <S extends TaskDefinition> Iterable<S> save(Iterable<S> iterableDefinitions) {
+		for (S definition : iterableDefinitions) {
+			save(definition);
+		}
+		return iterableDefinitions;
+	}
+
+	@Override
+	public <S extends TaskDefinition> S save(S definition) {
+		if(definitions.containsKey(definition.getTaskName())) {
+			throw new DuplicateTaskException(String.format("Cannot register task %s because another one has already been registered", definition.getTaskName()));
+		}
+
+		definitions.put(definition.getTaskName(), definition);
+
+		return definition;
+	}
+
+	@Override
+	public TaskDefinition findOne(String name) {
+		return definitions.get(name);
+	}
+
+	@Override
+	public boolean exists(String name) {
+		return definitions.containsKey(name);
+	}
+
+	@Override
+	public Iterable<TaskDefinition> findAll() {
+		return Collections.unmodifiableCollection(definitions.values());
+	}
+
+	@Override
+	public Iterable<TaskDefinition> findAll(Iterable<String> names) {
+		List<TaskDefinition> results = new ArrayList<>();
+		for (String s : names) {
+			if (definitions.containsKey(s)){
+				results.add(definitions.get(s));
+			}
+		}
+		return results;
+	}
+
+	@Override
+	public long count() {
+		return definitions.size();
+	}
+
+	@Override
+	public void delete(String name) {
+		definitions.remove(name);
+	}
+
+	@Override
+	public void delete(TaskDefinition definition) {
+		delete(definition.getTaskName());
+	}
+
+	@Override
+	public void delete(Iterable<? extends TaskDefinition> definitions) {
+		for (TaskDefinition definition : definitions){
+			delete(definition);
+		}
+	}
+
+	@Override
+	public void deleteAll() {
+		definitions.clear();
+	}
+
+}

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/repository/TaskDefinitionRepository.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/repository/TaskDefinitionRepository.java
@@ -1,0 +1,10 @@
+package org.springframework.cloud.data.rest.repository;
+
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+/**
+ * @author Michael Minella
+ */
+public interface TaskDefinitionRepository extends PagingAndSortingRepository<TaskDefinition, String> {
+}

--- a/spring-cloud-data-rest/src/test/java/org/springframework/cloud/data/rest/configuration/TestDependencies.java
+++ b/spring-cloud-data-rest/src/test/java/org/springframework/cloud/data/rest/configuration/TestDependencies.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.rest.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+
+/**
+ * @author Michael Minella
+ */
+@Configuration
+@EnableSpringDataWebSupport
+public class TestDependencies extends WebMvcConfigurationSupport {
+}

--- a/spring-cloud-data-rest/src/test/java/org/springframework/cloud/data/rest/controller/TaskControllerTests.java
+++ b/spring-cloud-data-rest/src/test/java/org/springframework/cloud/data/rest/controller/TaskControllerTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.rest.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.cloud.data.rest.config.AdminConfiguration;
+import org.springframework.cloud.data.rest.configuration.TestDependencies;
+import org.springframework.cloud.data.rest.repository.TaskDefinitionRepository;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * @author Michael Minella
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {AdminConfiguration.class, TestDependencies.class})
+@WebAppConfiguration
+public class TaskControllerTests {
+
+	@Autowired
+	private TaskDefinitionRepository repository;
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Before
+	public void setupMockMVC() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).defaultRequest(
+				get("/").accept(MediaType.APPLICATION_JSON)).build();
+	}
+
+	@After
+	public void tearDown() {
+		repository.deleteAll();
+	}
+
+	@Test
+	public void testSave() throws Exception {
+		assertEquals(0, repository.count());
+
+		mockMvc.perform(
+				post("/tasks/").param("name", "myTask").param("definition", "task")
+						.accept(MediaType.APPLICATION_JSON)).andDo(print())
+						.andExpect(status().isOk());
+
+		assertEquals(1, repository.count());
+
+		TaskDefinition myTask = repository.findOne("myTask");
+
+		assertTrue(CollectionUtils.isEmpty(myTask.getParameters()));
+		assertEquals("task", myTask.getTask());
+		assertEquals("myTask", myTask.getTaskName());
+	}
+
+	@Test
+	public void testSaveDuplicate() throws Exception {
+
+		repository.save(new TaskDefinition.Builder()
+				.setTaskName("myTask")
+				.setTask("task")
+				.build());
+
+		//TODO: Make this into an elegant error...
+		mockMvc.perform(
+				post("/tasks/").param("name", "myTask").param("definition", "task")
+						.accept(MediaType.APPLICATION_JSON)).andDo(print())
+						.andExpect(status().is5xxServerError());
+
+		assertEquals(1, repository.count());
+	}
+
+	@Test
+	public void testSaveWithParameters() throws Exception {
+		assertEquals(0, repository.count());
+
+		mockMvc.perform(
+				post("/tasks/").param("name", "myTask")
+						.param("definition", "task --foo=bar --bar=baz")
+						.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk());
+
+		assertEquals(1, repository.count());
+
+		TaskDefinition myTask = repository.findOne("myTask");
+
+		assertEquals("bar", myTask.getParameters().get("foo"));
+		assertEquals("baz", myTask.getParameters().get("bar"));
+		assertEquals("task", myTask.getTask());
+		assertEquals("myTask", myTask.getTaskName());
+	}
+
+	@Test
+	public void testDestroyTask() throws Exception {
+
+		repository.save(new TaskDefinition.Builder()
+				.setTaskName("myTask")
+				.setTask("task")
+				.build());
+
+		mockMvc.perform(
+				delete("/tasks/myTask").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk());
+
+		assertEquals(0, repository.count());
+	}
+
+	@Test
+	public void testDestroyTaskNotFound() throws Exception {
+
+		mockMvc.perform(
+				delete("/tasks/myTask").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk());
+
+		assertEquals(0, repository.count());
+	}
+}

--- a/spring-cloud-data-rest/src/test/java/org/springframework/cloud/data/rest/repository/InMemoryTaskDefinitionRepositoryTests.java
+++ b/spring-cloud-data-rest/src/test/java/org/springframework/cloud/data/rest/repository/InMemoryTaskDefinitionRepositoryTests.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.data.rest.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.cloud.data.core.TaskDefinition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * @author Michael Minella
+ */
+public class InMemoryTaskDefinitionRepositoryTests {
+
+	private InMemoryTaskDefinitionRepository repository;
+
+	@Before
+	public void setUp() {
+		repository = new InMemoryTaskDefinitionRepository();
+	}
+
+	@Test
+	public void testFindAllNone() {
+		Pageable pageable = new PageRequest(1, 10);
+
+		Page<TaskDefinition> page = repository.findAll(pageable);
+
+		assertEquals(page.getTotalElements(), 0);
+		assertEquals(page.getNumber(), 1);
+		assertEquals(page.getNumberOfElements(), 0);
+		assertEquals(page.getSize(), 10);
+		assertEquals(page.getContent().size(), 0);
+	}
+
+	@Test
+	public void testFindAllPageable() {
+		initializeRepository();
+		Pageable pageable = new PageRequest(1, 10);
+
+		Page<TaskDefinition> page = repository.findAll(pageable);
+
+		assertEquals(page.getTotalElements(), 3);
+		assertEquals(page.getNumber(), 1);
+		assertEquals(page.getNumberOfElements(), 3);
+		assertEquals(page.getSize(), 10);
+		assertEquals(page.getContent().size(), 3);
+	}
+
+	@Test(expected = DuplicateTaskException.class)
+	public void testSaveDuplicate() {
+		repository.save(buildDefinition("task1", "myTask", null));
+		repository.save(buildDefinition("task1", "myTask", null));
+	}
+
+	@Test(expected = DuplicateTaskException.class)
+	public void testSaveAllDuplicate() {
+		List<TaskDefinition> definitions = new ArrayList<>();
+		definitions.add(buildDefinition("task1", "myTask", null));
+
+		repository.save(buildDefinition("task1", "myTask", null));
+		repository.save(definitions);
+	}
+
+	@Test
+	public void testFindOneNoneFound() {
+		assertNull(repository.findOne("notFound"));
+
+		initializeRepository();
+
+		assertNull(repository.findOne("notFound"));
+	}
+
+	@Test
+	public void testFindOne() {
+		TaskDefinition definition = buildDefinition("task1", "myTask", null);
+		repository.save(definition);
+		repository.save(buildDefinition("task2", "myTask", null));
+		repository.save(buildDefinition("task3", "myTask", null));
+
+		assertEquals(definition, repository.findOne("task1"));
+	}
+
+	@Test
+	public void testExists() {
+		assertFalse(repository.exists("exists"));
+
+		repository.save(buildDefinition("exists", "myExists", null));
+
+		assertTrue(repository.exists("exists"));
+	}
+
+	@Test
+	public void testFindAll() {
+		assertFalse(repository.findAll().iterator().hasNext());
+
+		initializeRepository();
+
+		Iterable<TaskDefinition> items = repository.findAll();
+
+		int count = 0;
+		for (TaskDefinition item : items) {
+			count++;
+		}
+
+		assertEquals(3, count);
+	}
+
+	@Test
+	public void testFindAllSpecific() {
+		assertFalse(repository.findAll().iterator().hasNext());
+
+		initializeRepository();
+
+		List<String> names = new ArrayList<>();
+		names.add("task1");
+		names.add("task2");
+
+		Iterable<TaskDefinition> items = repository.findAll(names);
+
+		int count = 0;
+		for (TaskDefinition item : items) {
+			count++;
+		}
+
+		assertEquals(2, count);
+	}
+
+	@Test
+	public void testCount() {
+		assertEquals(0, repository.count());
+
+		initializeRepository();
+
+		assertEquals(3, repository.count());
+	}
+
+	@Test
+	public void testDeleteNotFound() {
+		repository.delete("notFound");
+	}
+
+	@Test
+	public void testDelete() {
+		initializeRepository();
+
+		assertNotNull(repository.findOne("task2"));
+
+		repository.delete("task2");
+
+		assertNull(repository.findOne("task2"));
+	}
+
+	@Test
+	public void testDeleteDefinition() {
+		initializeRepository();
+
+		assertNotNull(repository.findOne("task2"));
+
+		repository.delete(buildDefinition("task2", "myTask", null));
+
+		assertNull(repository.findOne("task2"));
+	}
+
+	@Test
+	public void testDeleteMultipleDefinitions() {
+		initializeRepository();
+
+		assertNotNull(repository.findOne("task1"));
+		assertNotNull(repository.findOne("task2"));
+
+		repository.delete(Arrays.asList(buildDefinition("task1", "myTask", null), buildDefinition("task2", "myTask", null)));
+
+		assertNull(repository.findOne("task1"));
+		assertNull(repository.findOne("task2"));
+	}
+
+	@Test
+	public void testDeleteAllNone() {
+		repository.deleteAll();
+	}
+
+	@Test
+	public void testDeleteAll() {
+		initializeRepository();
+
+		assertEquals(3, repository.count());
+		repository.deleteAll();
+		assertEquals(0, repository.count());
+	}
+
+	private void initializeRepository() {
+		repository.save(buildDefinition("task1", "myTask", null));
+		repository.save(buildDefinition("task2", "myTask", null));
+		repository.save(buildDefinition("task3", "myTask", null));
+	}
+
+	private TaskDefinition buildDefinition(String taskName, String task, Map<String, String> parameters) {
+		return new TaskDefinition.Builder().setTaskName(taskName)
+				.setTask(task)
+				.addParameters(parameters)
+				.build();
+	}
+}


### PR DESCRIPTION
This commit introduces the ability to parse the DSL to define a task and
register the resulting task in an in memory registry.  Future commits
will address the launching of this task via various mechanisms.