### PR TITLE
Spring Data Docker deploy matches SCS

### DIFF
--- a/spring-cloud-data-rest/.dockerignore
+++ b/spring-cloud-data-rest/.dockerignore
@@ -1,0 +1,3 @@
+*/*-javadoc.jar
+*/*-sources.jar
+*/*jar.original

--- a/spring-cloud-data-rest/pom.xml
+++ b/spring-cloud-data-rest/pom.xml
@@ -17,6 +17,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>org.springframework.cloud.data.rest.AdminApplication</start-class>
+		<docker.image.prefix>springcloud</docker.image.prefix>
+		<docker.image.name>data-admin</docker.image.name>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -80,6 +82,25 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<classifier>exec</classifier>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>0.2.3</version>
+				<configuration>
+					<imageName>${docker.image.prefix}/${docker.image.name}</imageName>
+					<dockerDirectory>src/main/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}-exec.jar</include>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-data-rest/pom.xml
+++ b/spring-cloud-data-rest/pom.xml
@@ -82,9 +82,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<classifier>exec</classifier>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>com.spotify</groupId>
@@ -97,7 +94,7 @@
 						<resource>
 							<targetPath>/</targetPath>
 							<directory>${project.build.directory}</directory>
-							<include>${project.build.finalName}-exec.jar</include>
+							<include>${project.build.finalName}.jar</include>
 						</resource>
 					</resources>
 				</configuration>

--- a/spring-cloud-data-rest/src/main/docker/Dockerfile
+++ b/spring-cloud-data-rest/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM java:8
 VOLUME /tmp
-ADD target/spring-cloud-data-rest-1.0.0.BUILD-SNAPSHOT.jar data-admin.jar
+ADD *-exec.jar  data-admin.jar
 RUN bash -c 'touch /data-admin.jar'
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/data-admin.jar"]

--- a/spring-cloud-data-rest/src/main/docker/Dockerfile
+++ b/spring-cloud-data-rest/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM java:8
 VOLUME /tmp
-ADD *-exec.jar  data-admin.jar
+ADD *.jar  data-admin.jar
 RUN bash -c 'touch /data-admin.jar'
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/data-admin.jar"]


### PR DESCRIPTION
* added -exec extension to spring cloud data jar for consistency with SCS
* updated the Dockerfile so that it will search for -exec.jar instead of the hardcoded snapshot jar
* moved Dockerfile into the code.
* updated data-admin pom to include docker plugin