### PR TITLE
Setup Admin UI

### DIFF
--- a/spring-cloud-data-rest/pom.xml
+++ b/spring-cloud-data-rest/pom.xml
@@ -51,6 +51,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.xd</groupId>
+			<artifactId>spring-xd-admin-ui-client</artifactId>
+			<version>1.2.1.RELEASE</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/AdminController.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/AdminController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Controller for the root resource of the admin server.
  *
  * @author Patrick Peralta
+ * @author Ilayaperumal Gopinathan
  */
 @RestController
 public class AdminController {
@@ -55,12 +56,22 @@ public class AdminController {
 	 *
 	 * @return {@code ResourceSupport} object containing the admin server's resources
 	 */
-	@RequestMapping
+	@RequestMapping("/")
 	public ResourceSupport info() {
 		ResourceSupport resourceSupport = new ResourceSupport();
 		resourceSupport.add(entityLinks.linkFor(StreamDefinitionResource.class).withRel("streams"));
 		resourceSupport.add(entityLinks.linkFor(TaskDefinitionResource.class).withRel("tasks"));
 		return resourceSupport;
+	}
+
+	@RequestMapping("/admin-ui/")
+	String index() {
+		return "forward:/admin-ui/index.html";
+	}
+
+	@RequestMapping("/admin-ui")
+	String indexWithoutTrailingSlash() {
+		return "redirect:/admin-ui/";
 	}
 
 }

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/SecurityController.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/controller/SecurityController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Security controller that returns authentication information.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@RestController
+@RequestMapping("/security/info")
+public class SecurityController {
+
+	@Autowired
+	private Environment environment;
+
+	/**
+	 * Return security information.
+	 */
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public boolean getSecurityInfo() {
+		//todo: Add SecurityResource with authentication information
+		return environment.getRequiredProperty("security.basic.enabled", boolean.class);
+	}
+
+}

--- a/spring-cloud-data-rest/src/main/resources/application.yml
+++ b/spring-cloud-data-rest/src/main/resources/application.yml
@@ -2,3 +2,6 @@ server:
   port: 9393
 management:
   contextPath: /management
+security:
+  basic:
+    enabled: false


### PR DESCRIPTION
 - Port minimal configurations required to setup admin UI
 - This change currently uses `spring-xd-ui` artifact explicitly
 - The inclusion of `SecurityController` is unavoidable since the
XD admin UI client mandates the check on security controller info

Use spring-xd-admin-ui-client directly

Fix admin info request mapping