### PR TITLE
XD-3384 Add base features for yarn deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,61 @@ all stream commands are supported in the shell when running on Lattice:
 ## Running on Cloud Foundry
 
 *work in progress, stay tuned!*
+
+## Running on Hadoop YARN
+
+Current YARN configuration is set to use localhost meaning this can only be run against local cluster. Also all commands needs to be run from a project root.
+
+1\. build packages
+
+```
+$ mvn clean package
+```
+
+2\. start Redis locally via `redis-server`
+
+3\. optionally wipe existing data on `hdfs`
+
+```
+$ hdfs dfs -rm -R /app/app
+```
+
+4\. start cli app, push and submit app to yarn
+
+```
+$ java -jar spring-cloud-data-yarn/spring-cloud-data-yarn-client/target/spring-cloud-data-yarn-client-1.0.0.BUILD-SNAPSHOT.jar shell
+Spring YARN Cli (v2.3.0.M1)
+Hit TAB to complete. Type 'help' and hit RETURN for help, and 'exit' to quit.
+$ push
+New version installed
+$ submit
+New instance submitted with id application_1439285616431_0010
+$ submitted 
+  APPLICATION ID                  USER          NAME                        QUEUE    TYPE  STARTTIME       FINISHTIME  STATE    FINALSTATUS  ORIGINAL TRACKING URL
+  ------------------------------  ------------  --------------------------  -------  ----  --------------  ----------  -------  -----------  --------------------------
+  application_1439285616431_0010  jvalkealahti  spring-cloud-data-yarn-app  default  XD    12/08/15 08:32  N/A         RUNNING  UNDEFINED    http://192.168.122.1:51656
+```
+
+5\. start `spring-cloud-data-rest` with `yarn` profile
+
+```
+$ java -Dspring.profiles.active=yarn -jar spring-cloud-data-rest/target/spring-cloud-data-rest-1.0.0.BUILD-SNAPSHOT.jar
+```
+
+6\. start `spring-cloud-data-shell`
+
+```
+java -jar spring-cloud-data-shell/target/spring-cloud-data-shell-1.0.0.BUILD-SNAPSHOT.jar
+
+cloud-data:>stream create --name ticktock --definition "time|log" --deploy
+Created and deployed new stream 'ticktock'
+
+cloud-data:>stream list
+  Stream Name  Stream Definition  Status
+  -----------  -----------------  --------
+  ticktock     time|log           deployed
+
+cloud-data:>stream destroy --name ticktock
+Destroyed stream 'ticktock'
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<module>spring-cloud-data-rest</module>
 		<module>spring-cloud-data-rest-client</module>
 		<module>spring-cloud-data-shell</module>
+		<module>spring-cloud-data-yarn</module>
 		<!-- module>docs</module -->
 	</modules>
 	<dependencyManagement>

--- a/spring-cloud-data-module-deployers/pom.xml
+++ b/spring-cloud-data-module-deployers/pom.xml
@@ -22,6 +22,7 @@
 		<module>spring-cloud-data-module-deployer-local</module>
 		<module>spring-cloud-data-module-deployer-lattice</module>
 		<module>spring-cloud-data-module-deployer-cloudfoundry</module>
+		<module>spring-cloud-data-module-deployer-yarn</module>
 	</modules>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/README.md
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/README.md
@@ -1,0 +1,1 @@
+SPI implementation for deploying [Spring Cloud Stream](https://github.com/spring-cloud/spring-cloud-stream) modules into yarn.

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/pom.xml
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-cloud-data-module-deployer-yarn</artifactId>
+	<packaging>jar</packaging>
+	<name>spring-cloud-data-module-deployer-yarn</name>
+	<description>Yarn module deployer SPI implementation</description>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-data-module-deployers-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-yarn-boot</artifactId>
+			<version>2.2.0.M1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-data-module-deployer-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-module-launcher</artifactId>
+			<version>${spring-cloud-stream.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.deployer.yarn;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.data.core.ModuleCoordinates;
+import org.springframework.cloud.data.core.ModuleDefinition;
+import org.springframework.cloud.data.core.ModuleDeploymentId;
+import org.springframework.cloud.data.core.ModuleDeploymentRequest;
+import org.springframework.cloud.data.module.ModuleStatus;
+import org.springframework.cloud.data.module.deployer.ModuleDeployer;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.boot.app.YarnContainerClusterApplication;
+import org.springframework.yarn.boot.app.YarnInfoApplication;
+
+/**
+ * {@link ModuleDeployer} which communicates to XD's yarn app running
+ * on a hadoop cluster waiting for deployment requests. This app is
+ * utilising spring yarn's container grouping functionality to create a
+ * new group per module type which then allows all modules to share same
+ * settings and group itself can controlled, i.e. ramp up/down or shutdown/destroy
+ * whole group.
+ *
+ * @author Janne Valkealahti
+ */
+public class YarnModuleDeployer implements ModuleDeployer {
+
+	private static final Logger logger = LoggerFactory.getLogger(YarnModuleDeployer.class);
+	private static final String PREFIX = "spring.yarn.internal.ContainerClusterApplication.";
+
+	public YarnModuleDeployer() {
+	}
+
+	@Override
+	public ModuleDeploymentId deploy(ModuleDeploymentRequest request) {
+		int count = request.getCount();
+		ModuleCoordinates coordinates = request.getCoordinates();
+		ModuleDefinition definition = request.getDefinition();
+		logger.info("deploying request for definition: " + definition);
+
+		ModuleDeploymentId moduleDeploymentId = new ModuleDeploymentId(definition.getGroup(), definition.getLabel());
+		String clusterId = sanitizeClusterId(convertFromModuleDeploymentId(moduleDeploymentId));
+
+		String yarnApplicationId = findRunningXdYarnApp();
+		logger.info("Using application id " + yarnApplicationId);
+		String module = coordinates.toString();
+		logger.info("deploying module: " + module);
+
+		Map<String, String> definitionParameters = definition.getParameters();
+		Map<String, String> deploymentProperties = request.getDeploymentProperties();
+		logger.info("definitionParameters: " + definitionParameters);
+		logger.info("deploymentProperties: " + deploymentProperties);
+
+		// Using same app instance yarn boot cli is using to
+		// communicate with an app running on yarn via its boot actuator
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX + "operation", "CLUSTERCREATE");
+		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX + "clusterId", clusterId);
+		appProperties.setProperty(PREFIX + "clusterDef", "module-template");
+		appProperties.setProperty(PREFIX + "projectionType", "default");
+		appProperties.setProperty(PREFIX + "projectionData.any", Integer.toString(count));
+		appProperties.setProperty(PREFIX + "extraProperties.containerModules", module);
+		app.appProperties(appProperties);
+		String output = app.run();
+		logger.info("Output from YarnContainerClusterApplication run for CLUSTERCREATE: " + output);
+
+		app = new YarnContainerClusterApplication();
+		appProperties = new Properties();
+		appProperties.setProperty(PREFIX + "operation", "CLUSTERSTART");
+		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		output = app.run();
+		logger.info("Output from YarnContainerClusterApplication run for CLUSTERSTART: " + output);
+
+		return moduleDeploymentId;
+	}
+
+	@Override
+	public void undeploy(ModuleDeploymentId id) {
+		String clusterId = convertFromModuleDeploymentId(id);
+		String yarnApplicationId = findRunningXdYarnApp();
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX + "operation", "CLUSTERSTOP");
+		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		String output = app.run();
+		logger.info("Output from YarnContainerClusterApplication run for CLUSTERSTOP: " + output);
+	}
+
+	@Override
+	public ModuleStatus status(ModuleDeploymentId id) {
+		String yarnApplicationId = findRunningXdYarnApp();
+		String clusterId = convertFromModuleDeploymentId(id);
+
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX + "operation", "CLUSTERINFO");
+		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX + "verbose", "false");
+		appProperties.setProperty(PREFIX + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		String info = app.run();
+		logger.info("Output from YarnContainerClusterApplication run for CLUSTERINFO: " + info);
+
+		boolean deployed = false;
+		String[] lines = info.trim().split("\\r?\\n");
+		if (lines.length == 3 && lines[2].contains("RUNNING")) {
+			deployed = true;
+		}
+
+		YarnModuleInstanceStatus status = new YarnModuleInstanceStatus(id.toString(), deployed, null);
+		return ModuleStatus.of(id).with(status).build();
+	}
+
+	@Override
+	public Map<ModuleDeploymentId, ModuleStatus> status() {
+		HashMap<ModuleDeploymentId, ModuleStatus> statuses = new HashMap<ModuleDeploymentId, ModuleStatus>();
+		for (String clusterId : findRunningContainerClusters()) {
+			ModuleDeploymentId moduleDeploymentId = convertToModuleDeploymentId(clusterId);
+			statuses.put(moduleDeploymentId, status(moduleDeploymentId));
+		}
+		return statuses;
+	}
+
+	private static String findRunningXdYarnApp() {
+		YarnInfoApplication app = new YarnInfoApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.operation", "SUBMITTED");
+		appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.verbose", "false");
+		appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.type", "XD");
+		app.appProperties(appProperties);
+		String info = app.run();
+		logger.info("Full status response for SUBMITTED app " + info);
+
+		// TODO: either make this easier in YarnInfoApplication
+		//       or use rest api directly
+		String[] lines = info.split("\\r?\\n");
+		logger.info("Parsing application id from " + StringUtils.arrayToCommaDelimitedString(lines));
+		if (lines.length == 3) {
+			return lines[2].trim().split("\\s+")[0].trim();
+		} else {
+			return null;
+		}
+	}
+
+	private static Collection<String> findRunningContainerClusters() {
+		String yarnApplicationId = findRunningXdYarnApp();
+
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX + "operation", "CLUSTERSINFO");
+		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
+		app.appProperties(appProperties);
+		String info = app.run();
+		logger.info("Output from YarnContainerClusterApplication run for CLUSTERSINFO: " + info);
+
+		ArrayList<String> ids = new ArrayList<String>();
+		String[] lines = info.split("\\r?\\n");
+		if (lines.length > 2) {
+			for (int i = 2; i < lines.length; i++) {
+				ids.add(lines[i].trim());
+			}
+		}
+		return ids;
+	}
+
+	private static String convertFromModuleDeploymentId(ModuleDeploymentId moduleDeploymentId) {
+		return moduleDeploymentId.getGroup() + ":" + moduleDeploymentId.getLabel();
+	}
+
+	private static ModuleDeploymentId convertToModuleDeploymentId(String containerClusterName) {
+		String[] split = containerClusterName.split(":");
+		if (split.length == 2) {
+			return new ModuleDeploymentId(split[0], split[1]);
+		} else {
+			return null;
+		}
+	}
+
+	private static String sanitizeClusterId(String clusterId) {
+		// spring yarn bug which treats postfix after dot
+		// as file delimiter and removes it per default mvc
+		// feature. need to handle this in shdp
+		return clusterId.replaceAll("\\.", "_");
+	}
+
+}

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleInstanceStatus.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleInstanceStatus.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.deployer.yarn;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.data.module.ModuleInstanceStatus;
+import org.springframework.cloud.data.module.ModuleStatus;
+import org.springframework.cloud.data.module.ModuleStatus.State;
+
+/**
+ * {@link ModuleInstanceStatus} for modules deployed into yarn.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnModuleInstanceStatus implements ModuleInstanceStatus {
+
+	private final String id;
+
+	private final ModuleStatus.State state;
+
+	private final Map<String, String> attributes = new HashMap<String, String>();
+
+	public YarnModuleInstanceStatus(String id, boolean deployed, Map<String, String> attributes) {
+		this.id = id;
+		this.state = deployed ? ModuleStatus.State.deployed : ModuleStatus.State.unknown;
+		if (attributes != null) {
+			this.attributes.putAll(attributes);
+		}
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public State getState() {
+		return state;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		return attributes;
+	}
+
+}

--- a/spring-cloud-data-rest/pom.xml
+++ b/spring-cloud-data-rest/pom.xml
@@ -47,6 +47,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-data-module-deployer-yarn</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/AdminConfiguration.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/AdminConfiguration.java
@@ -32,9 +32,9 @@ import org.springframework.cloud.stream.module.launcher.ModuleLauncher;
 import org.springframework.cloud.stream.module.launcher.ModuleLauncherConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -51,11 +51,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  * @author Marius Bogoevici
  * @author Patrick Peralta
  * @author Thomas Risberg
+ * @author Janne Valkealahti
  */
 @Configuration
 @EnableHypermediaSupport(type = HAL)
 @EnableSpringDataWebSupport
-@Import(CloudConfiguration.class)
+@Import({ CloudConfiguration.class, YarnConfiguration.class })
 @ComponentScan(basePackages = "org.springframework.cloud.data.rest.controller")
 public class AdminConfiguration {
 
@@ -75,7 +76,7 @@ public class AdminConfiguration {
 	}
 
 	@Configuration
-	@Profile("!cloud")
+	@Conditional(LocalCondition.class)
 	@Import(ModuleLauncherConfiguration.class)
 	protected static class LocalConfig {
 

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/LocalCondition.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/LocalCondition.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition which is used to enable local deployer in case
+ * cloud or yarn profile is not enabled.
+ *
+ * @author Thomas Risberg
+ * @author Janne Valkealahti
+ */
+public class LocalCondition implements Condition {
+
+	@Override
+	public boolean matches(ConditionContext conditionContext, AnnotatedTypeMetadata annotatedTypeMetadata) {
+		List<String> profiles = Arrays.asList(conditionContext.getEnvironment().getActiveProfiles());
+		if (profiles.contains("cloud") || profiles.contains("yarn")) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/YarnConfiguration.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/config/YarnConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.config;
+
+import org.springframework.cloud.data.module.deployer.ModuleDeployer;
+import org.springframework.cloud.data.module.deployer.yarn.YarnModuleDeployer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Configuration for creating deployer bean for yarn if yarn
+ * profile is activated.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Profile("yarn")
+public class YarnConfiguration {
+
+	@Bean
+	public ModuleDeployer moduleDeployer() {
+		return new YarnModuleDeployer();
+	}
+
+}

--- a/spring-cloud-data-rest/src/main/resources/application.yml
+++ b/spring-cloud-data-rest/src/main/resources/application.yml
@@ -5,3 +5,6 @@ management:
 security:
   basic:
     enabled: false
+spring:
+  hadoop:
+    resourceManagerHost: localhost

--- a/spring-cloud-data-yarn/pom.xml
+++ b/spring-cloud-data-yarn/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud</groupId>
+	<artifactId>spring-cloud-data-yarn</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-data-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<modules>
+		<module>spring-cloud-data-yarn-appmaster</module>
+		<module>spring-cloud-data-yarn-container</module>
+		<module>spring-cloud-data-yarn-client</module>
+	</modules>
+
+<!--
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-yarn-boot</artifactId>
+			<version>2.3.0.M1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+-->
+
+</project>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.springframework.cloud</groupId>
+	<artifactId>spring-cloud-data-yarn-appmaster</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-data-yarn</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-yarn-boot</artifactId>
+			<version>2.3.0.M1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>1.3.0.BUILD-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>1.3.0.BUILD-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/AppmasterApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/AppmasterApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.yarn.appmaster;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Yarn application bootstrapping appmaster.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SpringBootApplication
+public class AppmasterApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AppmasterApplication.class, args);
+	}
+
+}

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/XdAppmaster.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/XdAppmaster.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.yarn.appmaster;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.springframework.yarn.am.cluster.ContainerCluster;
+import org.springframework.yarn.am.cluster.ManagedContainerClusterAppmaster;
+
+/**
+ * Custom yarn appmaster tweaking container launch settings.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class XdAppmaster extends ManagedContainerClusterAppmaster {
+
+	private final static Log log = LogFactory.getLog(XdAppmaster.class);
+
+	@Override
+	protected List<String> onContainerLaunchCommands(Container container, ContainerCluster cluster,
+			List<String> commands) {
+
+		ArrayList<String> list = new ArrayList<String>(commands);
+		Map<String, Object> extraProperties = cluster.getExtraProperties();
+
+		log.debug("onContainerLaunchCommands extraProperties=" + extraProperties);
+
+		if (extraProperties != null && extraProperties.containsKey("containerModules")) {
+			String value = "containerModules=" + cluster.getExtraProperties().get("containerModules");
+			list.add(Math.max(list.size() - 2, 0), value);
+		}
+		list.add(1, "-Dserver.port=0");
+		return list;
+	}
+
+}

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/resources/application.yml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+server:
+    port: 0
+endpoints:
+    shutdown:
+        enabled: true
+spring:
+    hadoop:
+        fsUri: hdfs://localhost:8020
+        resourceManagerHost: localhost
+    yarn:
+        appType: BOOT
+        appName: spring-cloud-data-yarn-app
+        applicationBaseDir: /app/
+        applicationDir: /app/spring-cloud-data-yarn-app/
+        appmaster:
+            appmasterClass: org.springframework.cloud.data.yarn.appmaster.XdAppmaster
+            keepContextAlive: true
+            containercluster:
+                enabled: true
+                clusters:
+                    module-template:
+                        resource:
+                            priority: 10
+                            memory: 64
+                            virtualCores: 1
+                        launchcontext:
+                            locality: false
+                            archiveFile: spring-cloud-data-yarn-container-1.0.0.BUILD-SNAPSHOT.jar
+        endpoints:
+            containercluster:
+                enabled: true
+            containerregister:
+                enabled: false

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/resources/log4j.properties
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%C{1}] - %m%n
+
+log4j.category.org.springframework.yarn=DEBUG
+log4j.category.org.springframework.boot=INFO
+log4j.category.hello.appmaster=INFO

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.springframework.cloud</groupId>
+	<artifactId>spring-cloud-data-yarn-client</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-data-yarn</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-yarn-boot</artifactId>
+			<version>2.3.0.M1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-yarn-boot-cli</artifactId>
+			<version>2.3.0.M1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/java/org/springframework/cloud/data/yarn/client/ClientApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/java/org/springframework/cloud/data/yarn/client/ClientApplication.java
@@ -1,0 +1,48 @@
+package org.springframework.cloud.data.yarn.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.cli.command.Command;
+import org.springframework.yarn.boot.cli.AbstractCli;
+import org.springframework.yarn.boot.cli.YarnClusterCreateCommand;
+import org.springframework.yarn.boot.cli.YarnClusterDestroyCommand;
+import org.springframework.yarn.boot.cli.YarnClusterInfoCommand;
+import org.springframework.yarn.boot.cli.YarnClusterModifyCommand;
+import org.springframework.yarn.boot.cli.YarnClusterStartCommand;
+import org.springframework.yarn.boot.cli.YarnClusterStopCommand;
+import org.springframework.yarn.boot.cli.YarnClustersInfoCommand;
+import org.springframework.yarn.boot.cli.YarnKillCommand;
+import org.springframework.yarn.boot.cli.YarnPushCommand;
+import org.springframework.yarn.boot.cli.YarnPushedCommand;
+import org.springframework.yarn.boot.cli.YarnSubmitCommand;
+import org.springframework.yarn.boot.cli.YarnSubmittedCommand;
+import org.springframework.yarn.boot.cli.YarnSubmittedCommand.SubmittedOptionHandler;
+import org.springframework.yarn.boot.cli.shell.ShellCommand;
+
+public class ClientApplication extends AbstractCli {
+
+	public static void main(String... args) {
+		List<Command> commands = new ArrayList<Command>();
+		commands.add(new YarnPushCommand());
+		commands.add(new YarnPushedCommand());
+		commands.add(new YarnSubmitCommand());
+		commands.add(new YarnSubmittedCommand(new SubmittedOptionHandler("XD")));
+		commands.add(new YarnKillCommand());
+		// disable due to boot #3724 which broke
+		// container registrar
+		//commands.add(new YarnShutdownCommand());
+		commands.add(new YarnClustersInfoCommand());
+		commands.add(new YarnClusterInfoCommand());
+		commands.add(new YarnClusterCreateCommand());
+		commands.add(new YarnClusterStartCommand());
+		commands.add(new YarnClusterStopCommand());
+		commands.add(new YarnClusterModifyCommand());
+		commands.add(new YarnClusterDestroyCommand());
+		ClientApplication app = new ClientApplication();
+		app.registerCommands(commands);
+		app.registerCommand(new ShellCommand(commands));
+		app.doMain(args);
+	}
+
+}

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/application.yml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+    main:
+        show_banner: false
+    hadoop:
+        fsUri: hdfs://localhost:8020
+        resourceManagerHost: localhost
+    yarn:
+        appType: XD
+        appName: spring-cloud-data-yarn-app
+        applicationBaseDir: /app/
+        applicationDir: /app/spring-cloud-data-yarn-app/
+        client:
+            clientClass: org.springframework.yarn.client.DefaultApplicationYarnClient
+            files:
+              - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/target/spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar"
+              - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-container/target/spring-cloud-data-yarn-container-1.0.0.BUILD-SNAPSHOT.jar"
+            launchcontext:
+                archiveFile: spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar
+            resource:
+                memory: 1g

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/log4j.properties
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootCategory=WARN, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%C{1}] - %m%n
+
+log4j.category.org.apache.hadoop=OFF

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.springframework.cloud</groupId>
+	<artifactId>spring-cloud-data-yarn-container</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-data-yarn</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-yarn-boot</artifactId>
+			<version>2.3.0.M1</version>
+			<exclusions>
+<!--
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+-->
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-module-launcher</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>1.3.0.BUILD-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>1.3.0.BUILD-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/java/org/springframework/cloud/data/yarn/container/ContainerApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/java/org/springframework/cloud/data/yarn/container/ContainerApplication.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.yarn.container;
+
+import java.util.Properties;
+import java.util.concurrent.Future;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.module.launcher.ModuleLauncher;
+import org.springframework.cloud.stream.module.launcher.ModuleLauncherConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.concurrent.SettableListenableFuture;
+import org.springframework.yarn.annotation.OnContainerStart;
+import org.springframework.yarn.annotation.YarnComponent;
+import org.springframework.yarn.annotation.YarnParameter;
+import org.springframework.yarn.annotation.YarnParameters;
+import org.springframework.yarn.container.YarnContainerSupport;
+
+/**
+ * Yarn application bootstrapping container and running modules.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SpringBootApplication
+@Import(ModuleLauncherConfiguration.class)
+@YarnComponent
+public class ContainerApplication extends YarnContainerSupport {
+
+	private final static Log log = LogFactory.getLog(ContainerApplication.class);
+
+	@Autowired
+	private ModuleLauncher moduleLauncher;
+
+	@OnContainerStart
+	public Future<Boolean> runModule(@YarnParameters Properties properties, @YarnParameter("containerModules") String module) {
+		log.info("runModule module=" + module);
+		log.info("runModule properies=" + properties);
+		log.info("moduleLauncher=" + moduleLauncher);
+
+		// we should somehow get status back from module
+		// launcher when it fails or finishes to set future
+		// indicating we're done. Naturally exception will
+		// terminate execution chain and container will exit.
+		SettableListenableFuture<Boolean> status = new SettableListenableFuture<Boolean>();
+		moduleLauncher.launch(new String[] { module }, new String[0]);
+		return status;
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(ContainerApplication.class, args);
+	}
+
+}

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/resources/application.yml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+server:
+    port: 0
+endpoints:
+    shutdown:
+        enabled: false
+spring:
+    hadoop:
+        fsUri: hdfs://localhost:8020
+        resourceManagerHost: localhost
+

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/resources/log4j.properties
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/resources/log4j.properties
@@ -1,0 +1,13 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%C{1}] [%t] - %m%n
+
+log4j.category.org.springframework.context=DEBUG
+log4j.category.org.springframework.beans=DEBUG
+log4j.category.org.springframework.yarn=DEBUG
+log4j.category.org.springframework.data.hadoop.store=INFO
+log4j.category.org.springframework.boot=DEBUG
+log4j.category.hello.container=INFO
+


### PR DESCRIPTION
- New spring-cloud-data-yarn app which has client, appmaster and container.
- New YarnModuleDeployer working with existing yarn app
- Changes to rest app to enable yarn deployer if `yarn` profile is activated.

Some notes about this PR:

- Some instructions in main README
- This is very basic POC to demonstrate that we can actually deploy something into yarn.
- I'm adding tests in next PR's
- Yarn app based on SHDP yarn container groups/clusters. Every group is sharing same settings and thus controls instances of a module. This group can to started, stopped and ramped up/down.
- I'm crafting some SHDP jira's order to make deployer code faster and more easier to use.
- No properties passed into modules.
- Should somehow get notification from ModuleLauncher when module errors/exist so that we can exit yarn container.
- Should think how base yarn control app(yarn app instance and its appmaster) can be deployed into yarn with streams.
- We can potentially have multiple yarn apps and from shell we should somehow control which one to talk to.
