### PR TITLE
dockerignore is no longer needed.

### DIFF
--- a/spring-cloud-data-rest/.dockerignore
+++ b/spring-cloud-data-rest/.dockerignore
@@ -1,3 +1,0 @@
-*/*-javadoc.jar
-*/*-sources.jar
-*/*jar.original


### PR DESCRIPTION
This is handled by the docker plugin resource section