### PR TITLE
XD-3377: Refactor Task parsing

### DIFF
--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/ModuleParser.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/dsl/ModuleParser.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.core.dsl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parser for generating {@link ModuleNode ModuleNodes} from {@link Tokens}.
+ * This class may serve as a base for higher level module processing, for instance
+ * streams or tasks.
+ *
+ * @author Andy Clement
+ * @author Patrick Peralta
+ */
+public class ModuleParser {
+
+	/**
+	 * Tokens resulting from DSL parsing.
+	 */
+	private final Tokens tokens;
+
+	/**
+	 * Construct a {@code ModuleParser} based on the provided {@link Tokens}.
+	 *
+	 * @param tokens tokens from which to construct this parser
+	 */
+	public ModuleParser(Tokens tokens) {
+		this.tokens = tokens;
+	}
+
+	/**
+	 * Return the {@link Tokens} this parser is using.
+	 *
+	 * @return tokens for this parser
+	 */
+	public Tokens getTokens() {
+		return tokens;
+	}
+
+	/**
+	 * Return a {@link ModuleNode} from the next token and advance
+	 * the token position.
+	 * <p>
+	 * Expected format:
+	 * {@code module: [label':']? identifier (moduleArguments)*}
+	 * </p>
+	 *
+	 * @return a module node resulting from the next token
+	 */
+	protected ModuleNode eatModule() {
+		Token label = null;
+		Token name = tokens.next();
+		if (!name.isKind(TokenKind.IDENTIFIER)) {
+			tokens.raiseException(name.startPos, DSLMessage.EXPECTED_MODULENAME,
+					name.data != null ? name.data : new String(name.getKind().tokenChars));
+		}
+		if (tokens.peek(TokenKind.COLON)) {
+			if (!tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.NO_WHITESPACE_BETWEEN_LABEL_NAME_AND_COLON);
+			}
+			tokens.next(); // swallow colon
+			label = name;
+			name = tokens.eat(TokenKind.IDENTIFIER);
+		}
+		Token moduleName = name;
+		tokens.checkpoint();
+		ArgumentNode[] args = eatModuleArgs();
+		int startPos = label != null ? label.startPos : moduleName.startPos;
+		return new ModuleNode(toLabelNode(label), moduleName.data, startPos, moduleName.endPos, args);
+	}
+
+	/**
+	 * Return an array of {@link ArgumentNode} and advance the token
+	 * position if the next token(s) contain arguments.
+	 * <p>
+	 * Expected format:
+	 * {@code moduleArguments : DOUBLE_MINUS identifier(name) EQUALS identifier(value)}
+	 *
+	 * @return array of arguments or {@code null} if the next token(s) do not
+	 * contain arguments
+	 */
+	protected ArgumentNode[] eatModuleArgs() {
+		List<ArgumentNode> args = null;
+		if (tokens.peek(TokenKind.DOUBLE_MINUS) && tokens.isNextAdjacent()) {
+			tokens.raiseException(tokens.peek().startPos,
+					DSLMessage.EXPECTED_WHITESPACE_AFTER_MODULE_BEFORE_ARGUMENT);
+		}
+		while (tokens.peek(TokenKind.DOUBLE_MINUS)) {
+			Token dashDash = tokens.next(); // skip the '--'
+			if (tokens.peek(TokenKind.IDENTIFIER) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.NO_WHITESPACE_BEFORE_ARG_NAME);
+			}
+			List<Token> argNameComponents = eatDottedName();
+			if (tokens.peek(TokenKind.EQUALS) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.NO_WHITESPACE_BEFORE_ARG_EQUALS);
+			}
+			tokens.eat(TokenKind.EQUALS);
+			if (tokens.peek(TokenKind.IDENTIFIER) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.NO_WHITESPACE_BEFORE_ARG_VALUE);
+			}
+			// Process argument value:
+			Token t = tokens.peek();
+			String argValue = eatArgValue();
+			tokens.checkpoint();
+			if (args == null) {
+				args = new ArrayList<ArgumentNode>();
+			}
+			args.add(new ArgumentNode(toData(argNameComponents), argValue,
+					dashDash.startPos, t.endPos));
+		}
+		return args == null ? null : args.toArray(new ArgumentNode[args.size()]);
+	}
+
+	/**
+	 * Return the argument value from the next token and advance the token position.
+	 * <p>
+	 * Expected format:
+	 * {@code argValue: identifier | literal_string}
+	 *
+	 * @return argument value
+	 */
+	protected String eatArgValue() {
+		Token t = tokens.next();
+		String argValue = null;
+		if (t.getKind() == TokenKind.IDENTIFIER) {
+			argValue = t.data;
+		}
+		else if (t.getKind() == TokenKind.LITERAL_STRING) {
+			String quotesUsed = t.data.substring(0, 1);
+			argValue = t.data.substring(1, t.data.length() - 1)
+					.replace(quotesUsed + quotesUsed, quotesUsed);
+		}
+		else {
+			tokens.raiseException(t.startPos, DSLMessage.EXPECTED_ARGUMENT_VALUE, t.data);
+		}
+		return argValue;
+	}
+
+	/**
+	 * Return an array of {@link Token} that are separated by a dot.
+	 * <p>
+	 * Expected format:
+	 * {@code identifier [DOT identifier]*}
+	 * @return array of tokens separated by a dot
+	 */
+	protected List<Token> eatDottedName() {
+		List<Token> result = new ArrayList<Token>(3);
+		Token name = tokens.next();
+		if (!name.isKind(TokenKind.IDENTIFIER)) {
+			tokens.raiseException(name.startPos, DSLMessage.NOT_EXPECTED_TOKEN,
+					name.data != null ? name.data : new String(name.getKind().tokenChars));
+		}
+		result.add(name);
+		while (tokens.peek(TokenKind.DOT)) {
+			if (!tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.NO_WHITESPACE_IN_DOTTED_NAME);
+			}
+			result.add(tokens.next()); // consume dot
+			if (tokens.peek(TokenKind.IDENTIFIER) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.NO_WHITESPACE_IN_DOTTED_NAME);
+			}
+			result.add(tokens.eat(TokenKind.IDENTIFIER));
+		}
+		return result;
+	}
+
+	/**
+	 * Create a new {@link LabelNode} based on the provided token.
+	 *
+	 * @param label token containing the label; may be {@code null}
+	 * @return new {@code LabelNode} instance based on the provided token,
+	 * or {@code null} if the provided token is {@code null}
+	 */
+	protected LabelNode toLabelNode(Token label) {
+		return label == null ? null : new LabelNode(label.data, label.startPos, label.endPos);
+	}
+
+	/**
+	 * Return the concatenation of the data of multiple tokens.
+	 *
+	 * @return string containing the data of multiple tokens
+	 */
+	protected String toData(Iterable<Token> iterable) {
+		StringBuilder result = new StringBuilder();
+		for (Token t : iterable) {
+			result.append(t.getKind().hasPayload() ? t.data : t.getKind().tokenChars);
+		}
+		return result.toString();
+	}
+
+	/**
+	 * Return a list of string representations of {@link Token Tokens}.
+	 *
+	 * @param tokens list of tokens to convert to a list of strings
+	 * @return list of strings for the provided tokens
+	 */
+	protected List<String> tokenListToStringList(List<Token> tokens) {
+		if (tokens.isEmpty()) {
+			return Collections.<String> emptyList();
+		}
+		List<String> data = new ArrayList<String>();
+		for (Token token : tokens) {
+			data.add(token.data);
+		}
+		return data;
+	}
+
+	/**
+	 * Return the string representation of a {@link Token}.
+	 *
+	 * @param t token
+	 * @return string representation of the provided token
+	 */
+	protected String toString(Token t) {
+		return t.getKind().hasPayload() ? t.stringValue() : new String(t.kind.getTokenChars());
+	}
+
+	/**
+	 * Verify the supplied name is a valid name. Valid names must follow the same
+	 * rules as Java identifiers, with the additional option to use a hyphen ('-')
+	 * after the first character.
+	 *
+	 * @param name the name to validate
+	 * @return true if name is valid
+	 */
+	protected boolean isValidName(String name) {
+		if (name.length() == 0) {
+			return false;
+		}
+		if (!Character.isJavaIdentifierStart(name.charAt(0))) {
+			return false;
+		}
+		for (int i = 1, max = name.length(); i < max; i++) {
+			char ch = name.charAt(i);
+			if (!(Character.isJavaIdentifierPart(ch) || ch == '-')) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/parser/StreamDefinitionParser.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/parser/StreamDefinitionParser.java
@@ -66,8 +66,7 @@ public class StreamDefinitionParser {
 	 * @return list of module definitions for the stream
 	 */
 	public List<ModuleDefinition> parse(String name, String dsl) {
-		StreamDslParser parser = new StreamDslParser();
-		return buildModuleDefinitions(name, parser.parse(name, dsl));
+		return buildModuleDefinitions(name, new StreamDslParser(name, dsl).parse());
 	}
 
 	/**

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/parser/TaskDefinitionParser.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/parser/TaskDefinitionParser.java
@@ -35,8 +35,7 @@ public class TaskDefinitionParser {
 	 * @return task definition
 	 */
 	public TaskDefinition parse(String name, String dsl) {
-		TaskDslParser parser = new TaskDslParser();
-		return buildModuleDefinitions(name, parser.parse(name, dsl));
+		return buildModuleDefinitions(name, new TaskDslParser(name, dsl).parse());
 	}
 
 	/**

--- a/spring-cloud-data-core/src/test/java/org/springframework/cloud/data/core/dsl/StreamDslParserTests.java
+++ b/spring-cloud-data-core/src/test/java/org/springframework/cloud/data/core/dsl/StreamDslParserTests.java
@@ -34,7 +34,7 @@ import org.springframework.cloud.data.core.parser.StreamDefinitionParser;
  * @author Andy Clement
  * @author David Turanski
  */
-public class StreamConfigParserTests {
+public class StreamDslParserTests {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -541,22 +541,12 @@ public class StreamConfigParserTests {
 		assertThat((String) ast.getModuleNodes().get(1).getArgumentsAsProperties().get("expression"), equalTo("payload.replace(\"abc\", '')"));
 	}
 
-
-	private StreamDslParser getParser() {
-		return new StreamDslParser();
-	}
-
 	StreamNode parse(String streamDefinition) {
-		return getParser().parse(streamDefinition);
+		return new StreamDslParser(streamDefinition).parse();
 	}
 
 	StreamNode parse(String streamName, String streamDefinition) {
-		StreamNode streamNode = getParser().parse(streamName, streamDefinition);
-		String sname = streamNode.getStreamName();
-		if (sname == null) {
-			sname = streamName;
-		}
-		return streamNode;
+		return new StreamDslParser(streamName, streamDefinition).parse();
 	}
 
 	private void checkForIllegalStreamName(String streamName, String streamDef) {

--- a/spring-cloud-data-core/src/test/java/org/springframework/cloud/data/core/dsl/TaskDslParserTests.java
+++ b/spring-cloud-data-core/src/test/java/org/springframework/cloud/data/core/dsl/TaskDslParserTests.java
@@ -35,7 +35,7 @@ import org.springframework.cloud.data.core.parser.TaskDefinitionParser;
  * @author David Turanski
  * @author Michael Minella
  */
-public class TaskConfigParserTests {
+public class TaskDslParserTests {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -248,16 +248,12 @@ public class TaskConfigParserTests {
 		assertEquals(mn.getArgumentsAsProperties().get("expression"), "payload.replace(\"abc\", '')");
 	}
 
-	private TaskDslParser getParser() {
-		return new TaskDslParser();
-	}
-
 	ModuleNode parse(String taskDefinition) {
-		return getParser().parse(taskDefinition);
+		return new TaskDslParser(taskDefinition).parse();
 	}
 
 	ModuleNode parse(String taskName, String taskDefinition) {
-		return getParser().parse(taskName, taskDefinition);
+		return new TaskDslParser(taskName, taskDefinition).parse();
 	}
 
 	private void checkForIllegalTaskName(String taskName, String taskDef) {


### PR DESCRIPTION
Follow up to 4d9ae06 / https://github.com/spring-cloud/spring-cloud-data/pull/31 for XD-3377. This includes:

 - extracting of module parsing to `ModuleParser`
 - `StreamDslParser` and `TaskDslParser` extend `ModuleParser`
 - Renamed tests to `StreamDslParserTests` and
   `TaskDslParserTests`