### PR TITLE
XD-3384 Fix admin server yarn profile

### DIFF
--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/AdminApplication.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/AdminApplication.java
@@ -17,12 +17,18 @@
 package org.springframework.cloud.data.admin;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.yarn.boot.YarnAppmasterAutoConfiguration;
+import org.springframework.yarn.boot.YarnClientAutoConfiguration;
+import org.springframework.yarn.boot.YarnContainerAutoConfiguration;
 
 /**
  * @author Mark Fisher
  */
 @SpringBootApplication
+@EnableAutoConfiguration(exclude = { YarnClientAutoConfiguration.class, YarnAppmasterAutoConfiguration.class,
+		YarnContainerAutoConfiguration.class })
 public class AdminApplication {
 
 	public static void main(String[] args) throws InterruptedException {

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/YarnConfiguration.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/YarnConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.data.admin.config;
 import org.springframework.cloud.data.module.deployer.ModuleDeployer;
 import org.springframework.cloud.data.module.deployer.yarn.YarnModuleDeployer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.Profile;
  * @author Janne Valkealahti
  *
  */
+@Configuration
 @Profile("yarn")
 public class YarnConfiguration {
 

--- a/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/AdminApplicationTests.java
+++ b/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/AdminApplicationTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.admin;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.cloud.data.module.deployer.local.LocalModuleDeployer;
+import org.springframework.cloud.data.module.deployer.yarn.YarnModuleDeployer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Generic tests for {@link AdminApplication}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class AdminApplicationTests {
+
+	@Test
+	public void testDefaultProfile() {
+		SpringApplication app = new SpringApplication(AdminApplication.class);
+		ConfigurableApplicationContext context = app.run(new String[0]);
+		assertThat(context.containsBean("moduleDeployer"), is(true));
+		assertThat(context.getBean("moduleDeployer"), instanceOf(LocalModuleDeployer.class));
+		context.close();
+	}
+
+	@Test
+	public void testYarnProfile() {
+		SpringApplication app = new SpringApplication(AdminApplication.class);
+		ConfigurableApplicationContext context = app.run(new String[] { "--spring.profiles.active=yarn" });
+		assertThat(context.containsBean("moduleDeployer"), is(true));
+		assertThat(context.getBean("moduleDeployer"), instanceOf(YarnModuleDeployer.class));
+		context.close();
+	}
+
+}


### PR DESCRIPTION
- I'm not sure if previous merge for XD-3384 was ok, but is broken now.
- AdminApplication/AdminConfiguration were changed to rely on
  component scan which did work with yarn profile because YarnConfiguration
  did have @Configuration and its bean 'yarnConfiguration' was overriden
  from spring-yarn autoconfiguration. This didn't cause trouble when YarnConfiguration
  were imported because bean name were then `org.springframework.cloud.data.admin.config.YarnConfiguration`.
  Component scan is creating different bean names, 'yarnConfiguration' in this case.
- Disabling spring yarn auto-config, classes are needed in future PR's so
  not removing deps.
- Add @Configuration to YarnConfiguration for scan to work.
- Add tests for default/yarn profiles. Couldn't add tests for
  cloud/lattice profiles because of error
  "org.springframework.cloud.CloudException: No suitable cloud connector found"