### PR TITLE
XD-3419: Redis module registry

### DIFF
--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/AdminConfiguration.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/AdminConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.cloud.data.admin.repository.TaskDefinitionRepository;
 import org.springframework.cloud.data.module.deployer.ModuleDeployer;
 import org.springframework.cloud.data.module.deployer.local.LocalModuleDeployer;
 import org.springframework.cloud.data.module.registry.ModuleRegistry;
-import org.springframework.cloud.data.module.registry.StubModuleRegistry;
+import org.springframework.cloud.data.module.registry.RedisModuleRegistry;
 import org.springframework.cloud.stream.module.launcher.ModuleLauncher;
 import org.springframework.cloud.stream.module.launcher.ModuleLauncherConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -76,8 +76,8 @@ public class AdminConfiguration {
 	}
 
 	@Bean
-	public ModuleRegistry moduleRegistry() {
-		return new StubModuleRegistry();
+	public ModuleRegistry moduleRegistry(RedisConnectionFactory redisConnectionFactory) {
+		return new RedisModuleRegistry(redisConnectionFactory);
 	}
 
 	@Configuration

--- a/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/configuration/TestDependencies.java
+++ b/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/configuration/TestDependencies.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.data.admin.configuration;
 
+import org.springframework.cloud.data.module.registry.ModuleRegistry;
+import org.springframework.cloud.data.module.registry.StubModuleRegistry;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
@@ -26,5 +29,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupp
 @Configuration
 @EnableSpringDataWebSupport
 public class TestDependencies extends WebMvcConfigurationSupport {
+
+	@Bean
+	public ModuleRegistry moduleRegistry() {
+		return new StubModuleRegistry();
+	}
 
 }

--- a/spring-cloud-data-module-registry/pom.xml
+++ b/spring-cloud-data-module-registry/pom.xml
@@ -28,5 +28,9 @@
 			<artifactId>spring-cloud-data-core</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-redis</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/RedisModuleRegistry.java
+++ b/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/RedisModuleRegistry.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.registry;
+
+import org.springframework.cloud.data.core.ModuleCoordinates;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/**
+ * {@link ModuleRegistry} implementation backed by Redis.
+ *
+ * @author Patrick Peralta
+ */
+public class RedisModuleRegistry implements ModuleRegistry {
+
+	/**
+	 * Prefix for keys used for storing module coordinates.
+	 */
+	public static final String KEY_PREFIX = "spring.cloud.module";
+
+	/**
+	 * Group ID for default modules.
+	 */
+	private static final String GROUP_ID = "org.springframework.cloud.stream.module";
+
+	/**
+	 * Version number for default modules.
+	 */
+	private static final String VERSION = "1.0.0.BUILD-SNAPSHOT";
+
+	/**
+	 * Redis operations template.
+	 */
+	private final RedisOperations<String, String> redisOperations;
+
+
+	/**
+	 * Construct a {@code RedisModuleRegistry} with the provided
+	 * {@link RedisConnectionFactory}.
+	 *
+	 * @param redisConnectionFactory connection factory for Redis
+	 */
+	public RedisModuleRegistry(RedisConnectionFactory redisConnectionFactory) {
+		redisOperations = new StringRedisTemplate(redisConnectionFactory);
+		populateDefaults();
+	}
+
+	/**
+	 * Populate the registry with default module coordinates; will
+	 * not overwrite existing values.
+	 */
+	private void populateDefaults() {
+		populateDefault("http", "source");
+		populateDefault("time", "source");
+		populateDefault("filter", "processor");
+		populateDefault("groovy-filter", "processor");
+		populateDefault("groovy-transform", "processor");
+		populateDefault("transform", "processor");
+		populateDefault("counter", "sink");
+		populateDefault("log", "sink");
+	}
+
+	/**
+	 * Populate the registry with default values for the provided
+	 * module name and type; will not overwrite existing values.
+	 *
+	 * @param name module name
+	 * @param type module type
+	 */
+	private void populateDefault(String name, String type) {
+		redisOperations.boundValueOps(keyFor(name, type))
+				.setIfAbsent(defaultCoordinatesFor(name + '-' + type).toString());
+	}
+
+	/**
+	 * Return the default coordinates for the provided module name.
+	 *
+	 * @param moduleName module name for which to provide default coordinates
+	 * @return default coordinates for the provided module
+	 */
+	private ModuleCoordinates defaultCoordinatesFor(String moduleName) {
+		return ModuleCoordinates.parse(String.format("%s:%s:%s", GROUP_ID, moduleName, VERSION));
+	}
+
+	@Override
+	public ModuleCoordinates findByNameAndType(String name, String type) {
+		String coordinates = redisOperations.boundValueOps(keyFor(name, type)).get();
+		return (coordinates == null ? null : ModuleCoordinates.parse(coordinates));
+	}
+
+	/**
+	 * Return the key for the given module name and type.
+	 *
+	 * @param name module name
+	 * @param type module type
+	 * @return key for the given module name and type
+	 */
+	private String keyFor(String name, String type) {
+		return String.format("%s:%s:%s", KEY_PREFIX, type, name);
+	}
+
+}


### PR DESCRIPTION
* Implementation of module registry backed by Redis
* Test configurations modified to use StubModuleRegistry so that tests don't require Redis
* Tweaks and doc added to AbstractShellIntegrationTest

**Reviewers:**
I am seeking opinions on whether each module should be simple key/value pair in Redis (as implemented), or if three hashes keyed by module type would be preferable.