### PR TITLE
Remove CloudScan from admin cloud config

### DIFF
--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/CloudConfiguration.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/CloudConfiguration.java
@@ -16,13 +16,18 @@
 
 package org.springframework.cloud.data.admin.config;
 
-import org.springframework.cloud.config.java.CloudScan;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
+import org.springframework.cloud.Cloud;
+import org.springframework.cloud.CloudFactory;
 import org.springframework.cloud.data.module.deployer.ModuleDeployer;
 import org.springframework.cloud.data.module.deployer.cloudfoundry.CloudFoundryModuleDeployer;
 import org.springframework.cloud.data.module.deployer.lattice.ReceptorModuleDeployer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 /**
  * Configuration for cloud profiles (cloud, lattice).
@@ -33,8 +38,22 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration
 @Profile("cloud")
-@CloudScan
 public class CloudConfiguration {
+
+	@AutoConfigureBefore(RedisAutoConfiguration.class)
+	protected static class RedisConfig {
+
+		@Bean
+		public Cloud cloud() {
+			return new CloudFactory().getCloud();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(RedisConnectionFactory.class)
+		RedisConnectionFactory redisConnectionFactory(Cloud cloud) {
+			return cloud.getSingletonServiceConnector(RedisConnectionFactory.class, null);
+		}
+	}
 
 	@Profile("lattice")
 	protected static class LatticeConfig {

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/CloudConfiguration.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/CloudConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.data.admin.config;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudFactory;
@@ -49,7 +48,6 @@ public class CloudConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnMissingBean(RedisConnectionFactory.class)
 		RedisConnectionFactory redisConnectionFactory(Cloud cloud) {
 			return cloud.getSingletonServiceConnector(RedisConnectionFactory.class, null);
 		}


### PR DESCRIPTION
 - Remove `@CloudScan` from CloudConfiguration and add explicit configuration
for `RedisConnectionFactory` bean
 - This will avoid creating any other service beans that might as well be created
during cloud scan