### PR TITLE
Add `spring-cloud-lattice` into dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,10 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-lattice-connector</artifactId>
+				<artifactId>spring-cloud-lattice</artifactId>
 				<version>${spring-cloud-lattice.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-lattice/pom.xml
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-lattice/pom.xml
@@ -20,12 +20,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-lattice-core</artifactId>
-			<version>${spring-cloud-lattice.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cloudfoundry.receptor</groupId>
 			<artifactId>receptor-client</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
 - This way the `spring-cloud-lattice-core`, `spring-cloud-lattice-connector` and
`receptor-client` versions can be management centrally