### PR TITLE
Remove explicit `cloud` profile for LRP request

### DIFF
--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-lattice/src/main/java/org/springframework/cloud/data/module/deployer/lattice/LrpModuleDeployer.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-lattice/src/main/java/org/springframework/cloud/data/module/deployer/lattice/LrpModuleDeployer.java
@@ -66,7 +66,6 @@ public class LrpModuleDeployer implements ModuleDeployer {
 		List<EnvironmentVariable> environmentVariables = new ArrayList<EnvironmentVariable>();
 		Collections.addAll(environmentVariables, lrp.getEnv());
 		environmentVariables.add(new EnvironmentVariable("MODULES", request.getCoordinates().toString()));
-		environmentVariables.add(new EnvironmentVariable("SPRING_PROFILES_ACTIVE", "cloud"));
 		for (Map.Entry<String, String> entry : request.getDefinition().getParameters().entrySet()) {
 			environmentVariables.add(new EnvironmentVariable(entry.getKey(), entry.getValue()));
 		}


### PR DESCRIPTION
 - When deploying `s-c-s-module-launcher` docker image as LRP, the explicit `cloud` profile
need not be set as it needs to be auto activated by the module's lattice core dependency