### PR TITLE
XD-3425: Shell commands for module registry

### DIFF
--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/ModuleRegistryPopulator.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/ModuleRegistryPopulator.java
@@ -18,7 +18,11 @@ package org.springframework.cloud.data.admin.config;
 
 import javax.annotation.PostConstruct;
 
+import static org.springframework.cloud.data.core.ModuleType.*;
+
 import org.springframework.cloud.data.core.ModuleCoordinates;
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.cloud.data.module.registry.ModuleRegistration;
 import org.springframework.cloud.data.module.registry.ModuleRegistry;
 import org.springframework.util.Assert;
 
@@ -61,16 +65,16 @@ public class ModuleRegistryPopulator {
 	 */
 	@PostConstruct
 	public void populateDefaults() {
-		populateDefault("ftp", "source");
-		populateDefault("http", "source");
-		populateDefault("time", "source");
-		populateDefault("filter", "processor");
-		populateDefault("groovy-filter", "processor");
-		populateDefault("groovy-transform", "processor");
-		populateDefault("transform", "processor");
-		populateDefault("counter", "sink");
-		populateDefault("log", "sink");
-		populateDefault("redis", "sink");
+		populateDefault("ftp", source);
+		populateDefault("http", source);
+		populateDefault("time", source);
+		populateDefault("filter", processor);
+		populateDefault("groovy-filter", processor);
+		populateDefault("groovy-transform", processor);
+		populateDefault("transform", processor);
+		populateDefault("counter", sink);
+		populateDefault("log", sink);
+		populateDefault("redis", sink);
 	}
 
 	/**
@@ -80,9 +84,10 @@ public class ModuleRegistryPopulator {
 	 * @param name module name
 	 * @param type module type
 	 */
-	private void populateDefault(String name, String type) {
-		if (this.moduleRegistry.findByNameAndType(name, type) == null) {
-			this.moduleRegistry.save(name, type, defaultCoordinatesFor(name + '-' + type));
+	private void populateDefault(String name, ModuleType type) {
+		if (this.moduleRegistry.find(name, type) == null) {
+			this.moduleRegistry.save(new ModuleRegistration(name, type,
+					defaultCoordinatesFor(name + '-' + type)));
 		}
 	}
 

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/AdminController.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/AdminController.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.data.admin.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.data.rest.resource.CounterResource;
+import org.springframework.cloud.data.rest.resource.ModuleRegistrationResource;
 import org.springframework.cloud.data.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.data.rest.resource.TaskDefinitionResource;
 import org.springframework.hateoas.EntityLinks;
@@ -65,6 +66,7 @@ public class AdminController {
 		resourceSupport.add(entityLinks.linkToCollectionResource(TaskDefinitionResource.class).withRel("tasks"));
 		resourceSupport.add(entityLinks.linkToCollectionResource(CounterResource.class).withRel("counters"));
 		resourceSupport.add(new Link(entityLinks.linkToCollectionResource(CounterResource.class).getHref() + "/{name}").withRel("counters/counter"));
+		resourceSupport.add(entityLinks.linkToCollectionResource(ModuleRegistrationResource.class).withRel("modules"));
 		return resourceSupport;
 	}
 

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/ModuleController.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/ModuleController.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.admin.controller;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.data.core.ModuleCoordinates;
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.cloud.data.module.registry.ModuleRegistration;
+import org.springframework.cloud.data.module.registry.ModuleRegistry;
+import org.springframework.cloud.data.rest.resource.DetailedModuleRegistrationResource;
+import org.springframework.cloud.data.rest.resource.ModuleRegistrationResource;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Handles all Module related interactions.
+ *
+ * @author Glenn Renfro
+ * @author Mark Fisher
+ * @author Gunnar Hillert
+ * @author Eric Bottard
+ * @author Gary Russell
+ * @author Patrick Peralta
+ */
+@RestController
+@RequestMapping("/modules")
+@ExposesResourceFor(ModuleRegistrationResource.class)
+public class ModuleController {
+
+	private final Assembler moduleAssembler = new Assembler();
+
+	private final ModuleRegistry registry;
+
+	@Autowired
+	public ModuleController(ModuleRegistry registry) {
+		this.registry = registry;
+	}
+
+	/**
+	 * List module registrations.
+	 */
+	@RequestMapping(value = "", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public PagedResources<? extends ModuleRegistrationResource> list(Pageable pageable,
+			PagedResourcesAssembler<ModuleRegistration> assembler,
+			@RequestParam(value = "type", required = false) ModuleType type,
+			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
+
+		List<ModuleRegistration> list = new ArrayList<>(registry.findAll());
+		if (type != null) {
+			for (Iterator<ModuleRegistration> iterator = list.iterator(); iterator.hasNext();) {
+				if (iterator.next().getType() != type) {
+					iterator.remove();
+				}
+			}
+		}
+
+		// modules have a "natural" sort order of type followed by name,
+		// use that instead of what "pageable" indicates as a sort order
+		Collections.sort(list);
+		return assembler.toResource(new PageImpl<>(list), moduleAssembler);
+	}
+
+	/**
+	 * Retrieve detailed information about a particular module.
+	 *
+	 * @param type  module type
+	 * @param name  module name
+	 * @return detailed module information
+	 */
+	@RequestMapping(value = "/{type}/{name}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public DetailedModuleRegistrationResource info(@PathVariable("type") ModuleType type,
+			@PathVariable("name") String name) {
+		ModuleRegistration registration = registry.find(name, type);
+
+		return (registration == null ? null :
+				new DetailedModuleRegistrationResource(moduleAssembler.toResource(registration)));
+	}
+
+	/**
+	 * Register a module name and type with its Maven coordinates.
+	 *
+	 * @param type  module type
+	 * @param name  module name
+	 * @param coordinates  Maven coordinates for the module artifact
+	 * @param force if {@code true}, overwrites a pre-existing registration
+	 */
+	@RequestMapping(value = "/{type}/{name}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public void register(
+			@PathVariable("type") ModuleType type,
+			@PathVariable("name") String name,
+			@RequestParam("coordinates") String coordinates,
+			@RequestParam(value = "force", defaultValue = "false") boolean force) {
+		if (!force && registry.find(name, type) != null) {
+			return;
+		}
+		registry.save(new ModuleRegistration(name, type, ModuleCoordinates.parse(coordinates)));
+	}
+
+	/**
+	 * Unregister a module name and type.
+	 *
+	 * @param type the module type
+	 * @param name the module name
+	 */
+	@RequestMapping(value = "/{type}/{name}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public void unregister(@PathVariable("type") ModuleType type, @PathVariable("name") String name) {
+		registry.delete(name, type);
+	}
+
+	class Assembler extends ResourceAssemblerSupport<ModuleRegistration, ModuleRegistrationResource> {
+
+		public Assembler() {
+			super(ModuleController.class, ModuleRegistrationResource.class);
+		}
+
+		@Override
+		public ModuleRegistrationResource toResource(ModuleRegistration registration) {
+			return new ModuleRegistrationResource(registration.getName(),
+					registration.getType().name(), registration.getCoordinates().toString(), false);
+		}
+	}
+
+}

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/ModuleController.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/ModuleController.java
@@ -71,7 +71,7 @@ public class ModuleController {
 	 */
 	@RequestMapping(method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public PagedResources<? extends ModuleRegistrationResource> list(Pageable pageable,
+	public PagedResources<? extends ModuleRegistrationResource> list(
 			PagedResourcesAssembler<ModuleRegistration> assembler,
 			@RequestParam(value = "type", required = false) ModuleType type,
 			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/ModuleController.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/ModuleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -70,9 +69,8 @@ public class ModuleController {
 	/**
 	 * List module registrations.
 	 */
-	@RequestMapping(value = "", method = RequestMethod.GET)
+	@RequestMapping(method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
 	public PagedResources<? extends ModuleRegistrationResource> list(Pageable pageable,
 			PagedResourcesAssembler<ModuleRegistration> assembler,
 			@RequestParam(value = "type", required = false) ModuleType type,
@@ -102,8 +100,8 @@ public class ModuleController {
 	 */
 	@RequestMapping(value = "/{type}/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public DetailedModuleRegistrationResource info(@PathVariable("type") ModuleType type,
+	public DetailedModuleRegistrationResource info(
+			@PathVariable("type") ModuleType type,
 			@PathVariable("name") String name) {
 		ModuleRegistration registration = registry.find(name, type);
 
@@ -153,7 +151,7 @@ public class ModuleController {
 		@Override
 		public ModuleRegistrationResource toResource(ModuleRegistration registration) {
 			return new ModuleRegistrationResource(registration.getName(),
-					registration.getType().name(), registration.getCoordinates().toString(), false);
+					registration.getType().name(), registration.getCoordinates().toString());
 		}
 	}
 

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/TaskController.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/controller/TaskController.java
@@ -22,8 +22,10 @@ import org.springframework.cloud.data.admin.repository.TaskDefinitionRepository;
 import org.springframework.cloud.data.core.ModuleCoordinates;
 import org.springframework.cloud.data.core.ModuleDefinition;
 import org.springframework.cloud.data.core.ModuleDeploymentRequest;
+import org.springframework.cloud.data.core.ModuleType;
 import org.springframework.cloud.data.core.TaskDefinition;
 import org.springframework.cloud.data.module.deployer.ModuleDeployer;
+import org.springframework.cloud.data.module.registry.ModuleRegistration;
 import org.springframework.cloud.data.module.registry.ModuleRegistry;
 import org.springframework.cloud.data.rest.resource.TaskDefinitionResource;
 import org.springframework.data.domain.Pageable;
@@ -140,7 +142,12 @@ public class TaskController {
 		Assert.notNull(taskDefinition, String.format("no task defined: %s", name));
 
 		ModuleDefinition module = taskDefinition.getModuleDefinition();
-		ModuleCoordinates coordinates = this.registry.findByNameAndType(module.getName(), "task");
+		ModuleRegistration registration = this.registry.find(module.getName(), ModuleType.task);
+		if (registration == null) {
+			throw new IllegalArgumentException(String.format(
+					"Module %s of type %s not found in registry", module.getName(), ModuleType.task));
+		}
+		ModuleCoordinates coordinates = registration.getCoordinates();
 		// todo: pass deployment properties
 		this.moduleDeployer.deploy(new ModuleDeploymentRequest(module, coordinates));
 	}

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/ModuleDeploymentRequest.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/ModuleDeploymentRequest.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.data.core;
 import java.util.Collections;
 import java.util.Map;
 
+import org.springframework.util.Assert;
+
 /**
  * Representation of a module deployment request. This includes
  * module options defined at definition time (as part of a stream
@@ -57,6 +59,8 @@ public class ModuleDeploymentRequest {
 	 */
 	public ModuleDeploymentRequest(ModuleDefinition definition, ModuleCoordinates coordinates,
 			Map<String, String> deploymentProperties) {
+		Assert.notNull(definition, "definition must not be null");
+		Assert.notNull(coordinates, "coordinates must not be null");
 		this.definition = definition;
 		this.coordinates = coordinates;
 		this.deploymentProperties = deploymentProperties == null

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/ModuleType.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/ModuleType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/ModuleType.java
+++ b/spring-cloud-data-core/src/main/java/org/springframework/cloud/data/core/ModuleType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.core;
+
+/**
+ * Enumeration of module types.
+ *
+ * @author Patrick Peralta
+ */
+public enum ModuleType {
+	source, processor, sink, task
+}

--- a/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/ModuleRegistration.java
+++ b/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/ModuleRegistration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/ModuleRegistration.java
+++ b/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/ModuleRegistration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.registry;
+
+import org.springframework.cloud.data.core.ModuleCoordinates;
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.util.Assert;
+
+/**
+ * Registration for a module name, {@link ModuleType type}, and
+ * {@link ModuleCoordinates artifact coordinates}.
+ *
+ * @author Patrick Peralta
+ */
+public class ModuleRegistration implements Comparable<ModuleRegistration> {
+
+	/**
+	 * Module name.
+	 */
+	private final String name;
+
+	/**
+	 * Module type.
+	 */
+	private final ModuleType type;
+
+	/**
+	 * Maven coordinates for module artifact.
+	 */
+	private final ModuleCoordinates coordinates;
+
+	/**
+	 * Construct a {@code ModuleRegistration} object.
+	 *
+	 * @param name module name
+	 * @param type module type
+	 * @param coordinates coordinates for module artifact
+	 */
+	public ModuleRegistration(String name, ModuleType type, ModuleCoordinates coordinates) {
+		Assert.notNull(name, "name must not be null");
+		Assert.notNull(type, "type must not be null");
+		Assert.notNull(coordinates, "coordinates must not be null");
+		this.name = name;
+		this.type = type;
+		this.coordinates = coordinates;
+	}
+
+	/**
+	 * @see #name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @see #type
+	 */
+	public ModuleType getType() {
+		return type;
+	}
+
+	/**
+	 * @see #coordinates
+	 */
+	public ModuleCoordinates getCoordinates() {
+		return coordinates;
+	}
+
+	@Override
+	public String toString() {
+		return "ModuleRegistration{" +
+				"name='" + name + '\'' +
+				", type='" + type + '\'' +
+				", coordinates=" + coordinates +
+				'}';
+	}
+
+	@Override
+	public int compareTo(ModuleRegistration that) {
+		int i = this.type.compareTo(that.type);
+		if (i == 0) {
+			i = this.name.compareTo(that.name);
+		}
+		return i;
+	}
+
+}

--- a/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/ModuleRegistry.java
+++ b/spring-cloud-data-module-registry/src/main/java/org/springframework/cloud/data/module/registry/ModuleRegistry.java
@@ -17,23 +17,54 @@
 package org.springframework.cloud.data.module.registry;
 
 
-import org.springframework.cloud.data.core.ModuleCoordinates;
+import java.util.List;
+
+import org.springframework.cloud.data.core.ModuleType;
 
 /**
- * A module registry is used to lookup {@link ModuleCoordinates}s by name.
+ * {@code ModuleRegistry} is used to manage module registrations. This
+ * includes operations such as find, register, and delete.
+ *
+ * @see ModuleRegistration
  *
  * @author David Turanski
  * @author Mark Fisher
+ * @author Patrick Peralta
  */
 public interface ModuleRegistry {
 
 	/**
-	 * Look up the coordinates for a module jar by name and type.
+	 * Look up the registration for a module by name and type. If
+	 * a registration does not exist, {@code null} is returned.
+	 *
+	 * @param name the module name
+	 * @param type the module type
+	 *
+	 * @return registration for a module, or {@code null} if not found
+	 */
+	ModuleRegistration find(String name, ModuleType type);
+
+	/**
+	 * Return all module registrations.
+	 *
+	 * @return all module registrations
+	 */
+	List<ModuleRegistration> findAll();
+
+	/**
+	 * Save a new module registration. Pre-existing registrations
+	 * with a given name and type will be overwritten.
+	 *
+	 * @param registration module registration to save
+	 */
+	void save(ModuleRegistration registration);
+
+	/**
+	 * Unregister a module by name and type.
+	 *
 	 * @param name the module name
 	 * @param type the module type
 	 */
-	ModuleCoordinates findByNameAndType(String name, String type);
-
-	void save(String name, String type, ModuleCoordinates coordinates);
+	void delete(String name, ModuleType type);
 
 }

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/CloudDataOperations.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/CloudDataOperations.java
@@ -32,12 +32,12 @@ public interface CloudDataOperations {
 	 * Counter related operations.
 	 */
 	CounterOperations counterOperations();
-	
+
 	/**
 	 * Task related operations.
 	 */
 	TaskOperations taskOperations();
-	
+
 	/**
 	 * Module related operations.
 	 */

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/CloudDataOperations.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/CloudDataOperations.java
@@ -26,15 +26,21 @@ public interface CloudDataOperations {
 	/**
 	 * Stream related operations.
 	 */
-	public StreamOperations streamOperations();
+	StreamOperations streamOperations();
 
 	/**
 	 * Counter related operations.
 	 */
-	public CounterOperations counterOperations();
-
+	CounterOperations counterOperations();
+	
 	/**
 	 * Task related operations.
 	 */
-	public TaskOperations taskOperations();
+	TaskOperations taskOperations();
+	
+	/**
+	 * Module related operations.
+	 */
+	ModuleOperations moduleOperations();
+
 }

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/CloudDataTemplate.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/CloudDataTemplate.java
@@ -29,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
  *  @author Ilayaperumal Gopinathan
  *  @author Mark Fisher
  *  @author Glenn Renfro
+ *  @author Patrick Peralta
  */
 public class CloudDataTemplate implements CloudDataOperations {
 
@@ -40,7 +41,7 @@ public class CloudDataTemplate implements CloudDataOperations {
 	/**
 	 * Holds discovered URLs of the API.
 	 */
-	protected Map<String, UriTemplate> resources = new HashMap<String, UriTemplate>();
+	protected final Map<String, UriTemplate> resources = new HashMap<String, UriTemplate>();
 
 	/**
 	 * REST client for stream operations.
@@ -57,7 +58,12 @@ public class CloudDataTemplate implements CloudDataOperations {
 	 */
 	private final TaskOperations taskOperations;
 
-	
+	/**
+	 * REST client for module operations.
+	 */
+	private final ModuleOperations moduleOperations;
+
+
 	public CloudDataTemplate(URI baseURI) {
 		this.restTemplate = new RestTemplate();
 		restTemplate.getMessageConverters().add(new MappingJackson2HttpMessageConverter());
@@ -69,8 +75,9 @@ public class CloudDataTemplate implements CloudDataOperations {
 		resources.put("tasks/deployments", new UriTemplate(resourceSupport.getLink("tasks").getHref() + "/deployments"));
 
 		this.streamOperations = new StreamTemplate(restTemplate, resources);
-		this.taskOperations = new TaskTemplate(restTemplate, resources);
 		this.counterOperations = new CounterTemplate(restTemplate, resourceSupport);
+		this.taskOperations = new TaskTemplate(restTemplate, resources);
+		this.moduleOperations = new ModuleTemplate(restTemplate, resourceSupport);
 	}
 
 	@Override
@@ -86,6 +93,11 @@ public class CloudDataTemplate implements CloudDataOperations {
 	@Override
 	public TaskOperations taskOperations() {
 		return taskOperations;
+	}
+
+	@Override
+	public ModuleOperations moduleOperations() {
+		return moduleOperations;
 	}
 
 }

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.client;
+
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.cloud.data.rest.resource.DetailedModuleRegistrationResource;
+import org.springframework.cloud.data.rest.resource.ModuleRegistrationResource;
+import org.springframework.hateoas.PagedResources;
+
+/**
+ * Interface defining operations available for module registrations.
+ *
+ * @author Glenn Renfro
+ * @author Gunnar Hillert
+ * @author Eric Bottard
+ * @author Patrick Peralta
+ */
+public interface ModuleOperations {
+
+	/**
+	 * Return a list of all module registrations.
+	 *
+	 * @return list of all module registrations
+	 */
+	PagedResources<ModuleRegistrationResource> list();
+
+	/**
+	 * Return a list of all module registrations for the given {@link ModuleType}.
+	 *
+	 * @param type module type for which to return a list of registrations
+	 * @return list of all module registrations for the given module type
+	 */
+	PagedResources<ModuleRegistrationResource> list(ModuleType type);
+
+	/**
+	 * Retrieve information about a module registration.
+	 *
+	 * @param name name of module
+	 * @param type module type
+	 *
+	 * @return detailed information about a module registration
+	 */
+	DetailedModuleRegistrationResource info(String name, ModuleType type);
+
+	/**
+	 * Register a module name and type with its Maven coordinates.
+	 *
+	 * @param name  module name
+	 * @param type  module type
+	 * @param coordinates  Maven coordinates for the module artifact
+	 * @param force if {@code true}, overwrites a pre-existing registration
+	 */
+	ModuleRegistrationResource registerModule(String name, ModuleType type,
+			String coordinates, boolean force);
+
+	/**
+	 * Unregister a module name and type.
+	 *
+	 * @param name  module name
+	 * @param type  module type
+	 */
+	void unregisterModule(String name, ModuleType type);
+
+}

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
@@ -73,6 +73,6 @@ public interface ModuleOperations {
 	 * @param name  module name
 	 * @param type  module type
 	 */
-	void unregisterModule(String name, ModuleType type);
+	void unregister(String name, ModuleType type);
 
 }

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleOperations.java
@@ -64,7 +64,7 @@ public interface ModuleOperations {
 	 * @param coordinates  Maven coordinates for the module artifact
 	 * @param force if {@code true}, overwrites a pre-existing registration
 	 */
-	ModuleRegistrationResource registerModule(String name, ModuleType type,
+	ModuleRegistrationResource register(String name, ModuleType type,
 			String coordinates, boolean force);
 
 	/**

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.client;
+
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.cloud.data.rest.resource.DetailedModuleRegistrationResource;
+import org.springframework.cloud.data.rest.resource.ModuleRegistrationResource;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Implementation of {@link ModuleOperations} that uses {@link RestTemplate}
+ * to issue commands to the admin server.
+ *
+ * @author Eric Bottard
+ * @author Glenn Renfro
+ * @author Mark Fisher
+ * @author Gunnar Hillert
+ * @author Patrick Peralta
+ */
+public class ModuleTemplate implements ModuleOperations {
+
+	/**
+	 * Template used for http interaction.
+	 */
+	protected RestTemplate restTemplate;
+
+	/**
+	 * Template for URI creation.
+	 */
+	private final UriTemplate uriTemplate;
+
+	/**
+	 * Construct a {@code ModuleTemplate} object.
+	 *
+	 * @param restTemplate template for HTTP/rest commands
+	 * @param resourceSupport HATEOS link support
+	 */
+	public ModuleTemplate(RestTemplate restTemplate, ResourceSupport resourceSupport) {
+		this.restTemplate = restTemplate;
+		this.uriTemplate = new UriTemplate(resourceSupport.getLink("modules").getHref());
+	}
+
+	@Override
+	public PagedResources<ModuleRegistrationResource> list() {
+		return list(/* ModuleType */null);
+	}
+
+	@Override
+	public PagedResources<ModuleRegistrationResource> list(ModuleType type) {
+		// TODO handle pagination at the client side
+		String uri = uriTemplate + "?size=10000" + ((type == null) ? "" : "&type=" + type.name());
+		return restTemplate.getForObject(uri, ModuleRegistrationResource.Page.class);
+	}
+
+	@Override
+	public void unregisterModule(String name, ModuleType moduleType) {
+		String uri = uriTemplate.toString() + "/{type}/{name}";
+		restTemplate.delete(uri, moduleType.name(), name);
+	}
+
+	@Override
+	public DetailedModuleRegistrationResource info(String name, ModuleType type) {
+		String uri = uriTemplate.toString() + "/{type}/{name}";
+		return restTemplate.getForObject(uri, DetailedModuleRegistrationResource.class, type, name);
+	}
+
+	@Override
+	public ModuleRegistrationResource registerModule(String name, ModuleType type,
+			String coordinates, boolean force) {
+		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
+		values.add("coordinates", coordinates);
+		values.add("force", Boolean.toString(force));
+
+		String uri = uriTemplate.toString() + "/{type}/{name}";
+		return restTemplate.postForObject(uri, values, ModuleRegistrationResource.class,
+				type, name);
+	}
+}

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
@@ -72,7 +72,7 @@ public class ModuleTemplate implements ModuleOperations {
 	}
 
 	@Override
-	public void unregisterModule(String name, ModuleType moduleType) {
+	public void unregister(String name, ModuleType moduleType) {
 		String uri = uriTemplate.toString() + "/{type}/{name}";
 		restTemplate.delete(uri, moduleType.name(), name);
 	}

--- a/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
+++ b/spring-cloud-data-rest-client/src/main/java/org/springframework/cloud/data/rest/client/ModuleTemplate.java
@@ -84,7 +84,7 @@ public class ModuleTemplate implements ModuleOperations {
 	}
 
 	@Override
-	public ModuleRegistrationResource registerModule(String name, ModuleType type,
+	public ModuleRegistrationResource register(String name, ModuleType type,
 			String coordinates, boolean force) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("coordinates", coordinates);

--- a/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/DetailedModuleRegistrationResource.java
+++ b/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/DetailedModuleRegistrationResource.java
@@ -163,16 +163,13 @@ public class DetailedModuleRegistrationResource extends ModuleRegistrationResour
 			return name;
 		}
 
-
 		public String getType() {
 			return type;
 		}
 
-
 		public String getDescription() {
 			return description;
 		}
-
 
 		public String getDefaultValue() {
 			return defaultValue;

--- a/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/DetailedModuleRegistrationResource.java
+++ b/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/DetailedModuleRegistrationResource.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.resource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.hateoas.PagedResources;
+
+/**
+ * Extension of {@link ModuleRegistrationResource} that contains module options
+ * and other detailed module information.
+ *
+ * @author Eric Bottard
+ * @author Gunnar Hillert
+ * @author Patrick Peralta
+ */
+public class DetailedModuleRegistrationResource extends ModuleRegistrationResource {
+
+	/**
+	 * Optional short description of the module.
+	 */
+	private String shortDescription;
+
+	/**
+	 * List of module options.
+	 */
+	private final List<Option> options = new ArrayList<Option>();
+
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	protected DetailedModuleRegistrationResource() {
+	}
+
+	/**
+	 * Construct a {@code DetailedModuleRegistrationResource} object.
+	 *
+	 * @param name module name
+	 * @param type module type
+	 * @param coordinates Maven coordinates for module artifact
+	 * @param composed if true, this is a composed module
+	 */
+	public DetailedModuleRegistrationResource(String name, String type, String coordinates, boolean composed) {
+		super(name, type, coordinates, composed);
+	}
+
+	/**
+	 * Construct a {@code DetailedModuleRegistrationResource} object based
+	 * on the provided {@link ModuleRegistrationResource}.
+	 *
+	 * @param resource {@code ModuleRegistrationResource} from which to obtain
+	 *                 module registration data
+	 */
+	public DetailedModuleRegistrationResource(ModuleRegistrationResource resource) {
+		super(resource.getName(), resource.getType(), resource.getCoordinates(), resource.isComposed());
+	}
+
+	/**
+	 * Add a module option.
+	 *
+	 * @param option module option to add
+	 */
+	public void addOption(Option option) {
+		options.add(option);
+	}
+
+	/**
+	 * Return a list of module options.
+	 *
+	 * @return list of module options
+	 */
+	public List<Option> getOptions() {
+		return options;
+	}
+
+	/**
+	 * Set a description for this module.
+	 *
+	 * @param shortDescription description for module
+	 */
+	public void setShortDescription(String shortDescription) {
+		this.shortDescription = shortDescription;
+	}
+
+	/**
+	 * Return a description for this module.
+	 *
+	 * @return description for this module
+	 */
+	public String getShortDescription() {
+		return shortDescription;
+	}
+
+	/**
+	 * Class for a module option.
+	 */
+	public static class Option {
+
+		/**
+		 * Option name.
+		 */
+		private String name;
+
+		/**
+		 * Option type.
+		 */
+		private String type;
+
+		/**
+		 * Option description.
+		 */
+		private String description;
+
+		/**
+		 * Default value for option.
+		 */
+		private String defaultValue;
+
+		/**
+		 * If true, this is a hidden option.
+		 */
+		private boolean hidden;
+
+		/**
+		 * Default constructor for serialization frameworks.
+		 */
+		protected Option() {
+		}
+
+		/**
+		 * Construct a module {@code Option} object.
+		 *
+		 * @param name option name
+		 * @param type option type
+		 * @param description option description
+		 * @param defaultValue default value for option
+		 * @param hidden if true, this option is hidden
+		 */
+		public Option(String name, String type, String description, String defaultValue, boolean hidden) {
+			this.name = name;
+			this.type = type;
+			this.description = description;
+			this.defaultValue = defaultValue;
+			this.hidden = hidden;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+
+		public String getType() {
+			return type;
+		}
+
+
+		public String getDescription() {
+			return description;
+		}
+
+
+		public String getDefaultValue() {
+			return defaultValue;
+		}
+
+		public boolean isHidden() {
+			return hidden;
+		}
+
+		@Override
+		public String toString() {
+			return "Option [name=" + name + ", type=" + type + ", defaultValue=" + defaultValue + ", hidden=" + hidden
+					+ "]";
+		}
+	}
+
+	/**
+	 * Dedicated subclass to workaround type erasure.
+	 */
+	public static class Page extends PagedResources<DetailedModuleRegistrationResource> {
+	}
+
+}

--- a/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/DetailedModuleRegistrationResource.java
+++ b/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/DetailedModuleRegistrationResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -54,10 +54,9 @@ public class DetailedModuleRegistrationResource extends ModuleRegistrationResour
 	 * @param name module name
 	 * @param type module type
 	 * @param coordinates Maven coordinates for module artifact
-	 * @param composed if true, this is a composed module
 	 */
-	public DetailedModuleRegistrationResource(String name, String type, String coordinates, boolean composed) {
-		super(name, type, coordinates, composed);
+	public DetailedModuleRegistrationResource(String name, String type, String coordinates) {
+		super(name, type, coordinates);
 	}
 
 	/**
@@ -68,7 +67,7 @@ public class DetailedModuleRegistrationResource extends ModuleRegistrationResour
 	 *                 module registration data
 	 */
 	public DetailedModuleRegistrationResource(ModuleRegistrationResource resource) {
-		super(resource.getName(), resource.getType(), resource.getCoordinates(), resource.isComposed());
+		super(resource.getName(), resource.getType(), resource.getCoordinates());
 	}
 
 	/**

--- a/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/ModuleRegistrationResource.java
+++ b/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/ModuleRegistrationResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,11 +45,6 @@ public class ModuleRegistrationResource extends ResourceSupport {
 	private String coordinates;
 
 	/**
-	 * True if this is a composed module.
-	 */
-	private boolean composed;
-
-	/**
 	 * Default constructor for serialization frameworks.
 	 */
 	protected ModuleRegistrationResource() {
@@ -61,13 +56,11 @@ public class ModuleRegistrationResource extends ResourceSupport {
 	 * @param name module name
 	 * @param type module type
 	 * @param coordinates coordinates for module artifact
-	 * @param composed true if this is a composed module
 	 */
-	public ModuleRegistrationResource(String name, String type, String coordinates, boolean composed) {
+	public ModuleRegistrationResource(String name, String type, String coordinates) {
 		this.name = name;
 		this.type = type;
 		this.coordinates = coordinates;
-		this.composed = composed;
 	}
 
 	/**
@@ -89,13 +82,6 @@ public class ModuleRegistrationResource extends ResourceSupport {
 	 */
 	public String getCoordinates() {
 		return coordinates;
-	}
-
-	/**
-	 * @see #composed
-	 */
-	public boolean isComposed() {
-		return composed;
 	}
 
 	/**

--- a/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/ModuleRegistrationResource.java
+++ b/spring-cloud-data-rest-resource/src/main/java/org/springframework/cloud/data/rest/resource/ModuleRegistrationResource.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.rest.resource;
+
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * Rest resource for a module registration.
+ *
+ * @author Glenn Renfro
+ * @author Mark Fisher
+ * @author Patrick Peralta
+ */
+public class ModuleRegistrationResource extends ResourceSupport {
+
+	/**
+	 * Module name.
+	 */
+	private String name;
+
+	/**
+	 * Module type.
+	 */
+	private String type;
+
+	/**
+	 * Maven coordinates for module artifact. String is in standard format
+	 * such as {@code groupId:artifactId:version}.
+	 */
+	private String coordinates;
+
+	/**
+	 * True if this is a composed module.
+	 */
+	private boolean composed;
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	protected ModuleRegistrationResource() {
+	}
+
+	/**
+	 * Construct a {@code ModuleRegistrationResource}.
+	 *
+	 * @param name module name
+	 * @param type module type
+	 * @param coordinates coordinates for module artifact
+	 * @param composed true if this is a composed module
+	 */
+	public ModuleRegistrationResource(String name, String type, String coordinates, boolean composed) {
+		this.name = name;
+		this.type = type;
+		this.coordinates = coordinates;
+		this.composed = composed;
+	}
+
+	/**
+	 * @see #name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @see #type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @see #coordinates
+	 */
+	public String getCoordinates() {
+		return coordinates;
+	}
+
+	/**
+	 * @see #composed
+	 */
+	public boolean isComposed() {
+		return composed;
+	}
+
+	/**
+	 * Dedicated subclass to workaround type erasure.
+	 */
+	public static class Page extends PagedResources<ModuleRegistrationResource> {
+	}
+
+}

--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
@@ -140,7 +140,7 @@ public class ModuleCommands implements CommandMarker {
 					specifiedDefaultValue = "true",
 					unspecifiedDefaultValue = "false")
 			boolean force) {
-		moduleOperations().registerModule(name, type, coordinates, force);
+		moduleOperations().register(name, type, coordinates, force);
 		return String.format(("Successfully registered module '%s:%s'"), type, name);
 	}
 

--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,8 +49,6 @@ import org.springframework.shell.support.table.TableHeader;
 @Component
 public class ModuleCommands implements CommandMarker {
 
-	private final static String COMPOSE_MODULE = "module compose";
-
 	private final static String LIST_MODULES = "module list";
 
 	private final static String MODULE_INFO = "module info";
@@ -63,9 +61,7 @@ public class ModuleCommands implements CommandMarker {
 	private CloudDataShell cloudDataShell;
 
 
-	@CliAvailabilityIndicator({
-			COMPOSE_MODULE, LIST_MODULES, MODULE_INFO,
-			UNREGISTER_MODULE, REGISTER_MODULE})
+	@CliAvailabilityIndicator({LIST_MODULES, MODULE_INFO, UNREGISTER_MODULE, REGISTER_MODULE})
 	public boolean available() {
 		return cloudDataShell.getCloudDataOperations() != null;
 	}
@@ -123,25 +119,6 @@ public class ModuleCommands implements CommandMarker {
 			result.append(table.toString());
 		}
 		return result.toString();
-	}
-
-	@CliCommand(value = COMPOSE_MODULE, help = "Create a virtual module")
-	public String composeModule(
-			@CliOption(mandatory = true,
-					key = {"name", ""},
-					help = "the name to give to the module")
-			String name,
-			@CliOption(mandatory = true,
-					key = "definition",
-					optionContext = "completion-module disable-string-converter",
-					help = "module definition using xd dsl")
-			String dsl,
-			@CliOption(key = "force",
-					help = "force update if module already exists (only if not in use)",
-					specifiedDefaultValue = "true",
-					unspecifiedDefaultValue = "false")
-			boolean force) {
-		throw new UnsupportedOperationException("composed modules not yet supported");
 	}
 
 	@CliCommand(value = REGISTER_MODULE, help = "Register a new module")

--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.shell.command;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.cloud.data.rest.client.ModuleOperations;
+import org.springframework.cloud.data.rest.resource.DetailedModuleRegistrationResource;
+import org.springframework.cloud.data.rest.resource.DetailedModuleRegistrationResource.Option;
+import org.springframework.cloud.data.rest.resource.ModuleRegistrationResource;
+import org.springframework.cloud.data.shell.config.CloudDataShell;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.shell.support.table.TableRow;
+import org.springframework.stereotype.Component;
+import org.springframework.shell.support.table.Table;
+import org.springframework.shell.support.table.TableHeader;
+
+
+/**
+ * Commands for working with modules. Allows retrieval of information about
+ * available modules, as well as creating and removing module registrations.
+ *
+ * @author Glenn Renfro
+ * @author Eric Bottard
+ * @author Florent Biville
+ * @author David Turanski
+ * @author Patrick Peralta
+ */
+@Component
+public class ModuleCommands implements CommandMarker {
+
+	private final static String COMPOSE_MODULE = "module compose";
+
+	private final static String LIST_MODULES = "module list";
+
+	private final static String MODULE_INFO = "module info";
+
+	private final static String UNREGISTER_MODULE = "module unregister";
+
+	private static final String REGISTER_MODULE = "module register";
+
+	@Autowired
+	private CloudDataShell cloudDataShell;
+
+
+	@CliAvailabilityIndicator({
+			COMPOSE_MODULE, LIST_MODULES, MODULE_INFO,
+			UNREGISTER_MODULE, REGISTER_MODULE})
+	public boolean available() {
+		return cloudDataShell.getCloudDataOperations() != null;
+	}
+
+	@CliCommand(value = MODULE_INFO, help = "Get information about a module")
+	public String moduleInfo(
+			@CliOption(mandatory = true,
+					key = { "", "name" },
+					help = "name of the module to query")
+			String name,
+			@CliOption(mandatory = false,
+					key = {"type"},
+					help = "type of the module to query")
+			ModuleType type,
+			@CliOption(key = "hidden",
+					help = "whether to show 'hidden' options",
+					specifiedDefaultValue = "true",
+					unspecifiedDefaultValue = "false")
+			boolean showHidden) {
+		QualifiedModuleName module = processArgs(name, type);
+		DetailedModuleRegistrationResource info = moduleOperations().info(module.name, module.type);
+		List<Option> options = info.getOptions();
+		StringBuilder result = new StringBuilder();
+		result.append("Information about ")
+				.append(module.type.name())
+				.append(" module '")
+				.append(module.name)
+				.append("':\n\n");
+
+		result.append("Maven coordinates: ").append(info.getCoordinates()).append("\n\n");
+
+		if (info.getShortDescription() != null) {
+			result.append(info.getShortDescription()).append("\n\n");
+		}
+		if (options == null) {
+			result.append("Module options metadata is not available");
+		}
+		else {
+			Table table = new Table()
+					.addHeader(1, new TableHeader("Option Name"))
+					.addHeader(2, new TableHeader("Description"))
+					.addHeader(3, new TableHeader("Default"))
+					.addHeader(4, new TableHeader("Type"));
+			for (DetailedModuleRegistrationResource.Option o : options) {
+				if (!showHidden && o.isHidden()) {
+					continue;
+				}
+				final TableRow row = new TableRow();
+				row.addValue(1, o.getName())
+						.addValue(2, o.getDescription())
+						.addValue(3, prettyPrintDefaultValue(o))
+						.addValue(4, o.getType() == null ? "<unknown>" : o.getType());
+				table.getRows().add(row);
+			}
+			result.append(table.toString());
+		}
+		return result.toString();
+	}
+
+	@CliCommand(value = COMPOSE_MODULE, help = "Create a virtual module")
+	public String composeModule(
+			@CliOption(mandatory = true,
+					key = {"name", ""},
+					help = "the name to give to the module")
+			String name,
+			@CliOption(mandatory = true,
+					key = "definition",
+					optionContext = "completion-module disable-string-converter",
+					help = "module definition using xd dsl")
+			String dsl,
+			@CliOption(key = "force",
+					help = "force update if module already exists (only if not in use)",
+					specifiedDefaultValue = "true",
+					unspecifiedDefaultValue = "false")
+			boolean force) {
+		throw new UnsupportedOperationException("composed modules not yet supported");
+	}
+
+	@CliCommand(value = REGISTER_MODULE, help = "Register a new module")
+	public String registerModule(
+			@CliOption(mandatory = true,
+					key = { "", "name" },
+					help = "the name for the registered module")
+			String name,
+			@CliOption(mandatory = true,
+					key = {"type"},
+					help = "the type for the registered module")
+			ModuleType type,
+			@CliOption(mandatory = true,
+					key = {"coordinates"},
+					help = "coordinates to the module archive")
+			String coordinates,
+			@CliOption(key = "force",
+					help = "force update if module already exists (only if not in use)",
+					specifiedDefaultValue = "true",
+					unspecifiedDefaultValue = "false")
+			boolean force) {
+		moduleOperations().registerModule(name, type, coordinates, force);
+		return String.format(("Successfully registered module '%s:%s'"), type, name);
+	}
+
+	@CliCommand(value = UNREGISTER_MODULE, help = "Unregister a module")
+	public String unregisterModule(
+			@CliOption(mandatory = true,
+					key = { "", "name" },
+					help = "name of the module to unregister")
+			String name,
+			@CliOption(mandatory = false,
+					key = {"type"},
+					help = "type of the module to unregister")
+			ModuleType type) {
+
+		QualifiedModuleName module = processArgs(name, type);
+		moduleOperations().unregisterModule(module.name, module.type);
+		return String.format(("Successfully unregistered module '%s' with type %s"),
+				module.name, module.type);
+	}
+
+	@CliCommand(value = LIST_MODULES, help = "List all modules")
+	public Table listModules() {
+		PagedResources<ModuleRegistrationResource> modules = moduleOperations().list();
+		return new ModuleList(modules).renderByType();
+	}
+
+	/**
+	 * Escapes some special values so that they don't disturb console
+	 * rendering and are easier to read.
+	 */
+	private String prettyPrintDefaultValue(Option o) {
+		if (o.getDefaultValue() == null) {
+			return "<none>";
+		}
+		return o.getDefaultValue()
+				.replace("\n", "\\n")
+				.replace("\t", "\\t")
+				.replace("\f", "\\f");
+	}
+
+	private ModuleOperations moduleOperations() {
+		return cloudDataShell.getCloudDataOperations().moduleOperations();
+	}
+
+	/**
+	 * Return a {@link QualifiedModuleName} for the given arguments.
+	 * If {@code type} is {@code null}, the module type may be obtained
+	 * from the module name if the module name is in the format
+	 * {@code name:type}.
+	 *
+	 * @param name module name
+	 * @param type module type; may be {@code null}
+	 * @return {@code QualifiedModuleName} for the provided arguments
+	 */
+	private QualifiedModuleName processArgs(String name, ModuleType type) {
+		if (type == null) {
+			String[] split = name.split("\\:");
+			if (split.length != 2) {
+				throw new IllegalArgumentException(
+						String.format("Expected format of 'name:type' for module name %s", name));
+			}
+			return new QualifiedModuleName(split[0], ModuleType.valueOf(split[1]));
+		}
+		else {
+			return new QualifiedModuleName(name, type);
+		}
+	}
+
+	/**
+	 * Unique identifier for a module, including the name and type.
+	 */
+	private static class QualifiedModuleName {
+
+		public ModuleType type;
+
+		public String name;
+
+		public QualifiedModuleName(String name, ModuleType type) {
+			this.name = name;
+			this.type = type;
+		}
+	}
+
+}

--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleCommands.java
@@ -67,9 +67,9 @@ public class ModuleCommands implements CommandMarker {
 	}
 
 	@CliCommand(value = MODULE_INFO, help = "Get information about a module")
-	public String moduleInfo(
+	public String info(
 			@CliOption(mandatory = true,
-					key = { "", "name" },
+					key = {"", "name"},
 					help = "name of the module to query")
 			String name,
 			@CliOption(mandatory = false,
@@ -122,9 +122,9 @@ public class ModuleCommands implements CommandMarker {
 	}
 
 	@CliCommand(value = REGISTER_MODULE, help = "Register a new module")
-	public String registerModule(
+	public String register(
 			@CliOption(mandatory = true,
-					key = { "", "name" },
+					key = {"", "name"},
 					help = "the name for the registered module")
 			String name,
 			@CliOption(mandatory = true,
@@ -145,9 +145,9 @@ public class ModuleCommands implements CommandMarker {
 	}
 
 	@CliCommand(value = UNREGISTER_MODULE, help = "Unregister a module")
-	public String unregisterModule(
+	public String unregister(
 			@CliOption(mandatory = true,
-					key = { "", "name" },
+					key = {"", "name"},
 					help = "name of the module to unregister")
 			String name,
 			@CliOption(mandatory = false,
@@ -156,13 +156,13 @@ public class ModuleCommands implements CommandMarker {
 			ModuleType type) {
 
 		QualifiedModuleName module = processArgs(name, type);
-		moduleOperations().unregisterModule(module.name, module.type);
+		moduleOperations().unregister(module.name, module.type);
 		return String.format(("Successfully unregistered module '%s' with type %s"),
 				module.name, module.type);
 	}
 
 	@CliCommand(value = LIST_MODULES, help = "List all modules")
-	public Table listModules() {
+	public Table list() {
 		PagedResources<ModuleRegistrationResource> modules = moduleOperations().list();
 		return new ModuleList(modules).renderByType();
 	}

--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleList.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleList.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.shell.command;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.cloud.data.core.ModuleType;
+import org.springframework.cloud.data.rest.resource.ModuleRegistrationResource;
+import org.springframework.shell.support.table.Table;
+import org.springframework.shell.support.table.TableHeader;
+import org.springframework.shell.support.table.TableRow;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Knows how to render a {@link Table} of {@link ModuleRegistrationResource}.
+ *
+ * @author Florent Biville
+ * @author Eric Bottard
+ */
+class ModuleList {
+
+	private Iterable<ModuleRegistrationResource> modules;
+
+	private static final Map<String, Integer> typeToColumn = new LinkedHashMap<String, Integer>();
+
+	static {
+		for (int i = 0; i < ModuleType.values().length;) {
+			typeToColumn.put(ModuleType.values()[i].name(), ++i); // 1 based
+		}
+	}
+
+	public ModuleList(Iterable<ModuleRegistrationResource> modules) {
+		Assert.notNull(modules);
+		this.modules = modules;
+	}
+
+	public Table renderByType() {
+		Table table = new Table();
+		int i = 1;
+		Map<String, Integer> currentRowByType = new HashMap<String, Integer>();
+		for (String type : typeToColumn.keySet()) {
+			table.addHeader(i++, new TableHeader("    " + StringUtils.capitalize(type)));
+		}
+		for (ModuleRegistrationResource module : modules) {
+			TableRow row = rowForType(module.getType(), table, currentRowByType);
+			row.addValue(typeToColumn.get(module.getType()), cellValue(module));
+		}
+		return table;
+	}
+
+	private String cellValue(ModuleRegistrationResource module) {
+		return String.format("%s %s", module.isComposed() ? "(c)" : "   ", module.getName());
+	}
+
+	/**
+	 * Return the row to which a module of the given type should be added.
+	 * Will automatically grow the table if needed.
+	 */
+	private TableRow rowForType(String type, Table table, Map<String, Integer> currentRowByType) {
+		Integer value = currentRowByType.get(type);
+		if (value == null) {
+			value = 0;
+		}
+		currentRowByType.put(type, value + 1);
+		TableRow result = null;
+		if (value >= table.getRows().size()) {
+			result = new TableRow();
+			for (int i = 1; i <= typeToColumn.size(); i++) {
+				result.addValue(i, "");
+			}
+			table.getRows().add(result);
+		}
+		else {
+			result = table.getRows().get(value);
+		}
+		return result;
+	}
+}

--- a/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleList.java
+++ b/spring-cloud-data-shell/src/main/java/org/springframework/cloud/data/shell/command/ModuleList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -60,13 +60,9 @@ class ModuleList {
 		}
 		for (ModuleRegistrationResource module : modules) {
 			TableRow row = rowForType(module.getType(), table, currentRowByType);
-			row.addValue(typeToColumn.get(module.getType()), cellValue(module));
+			row.addValue(typeToColumn.get(module.getType()), module.getName());
 		}
 		return table;
-	}
-
-	private String cellValue(ModuleRegistrationResource module) {
-		return String.format("%s %s", module.isComposed() ? "(c)" : "   ", module.getName());
 	}
 
 	/**
@@ -79,7 +75,7 @@ class ModuleList {
 			value = 0;
 		}
 		currentRowByType.put(type, value + 1);
-		TableRow result = null;
+		TableRow result;
 		if (value >= table.getRows().size()) {
 			result = new TableRow();
 			for (int i = 1; i <= typeToColumn.size(); i++) {


### PR DESCRIPTION
New classes for module registration:
 * `ModuleRegistration`
 * `ModuleRegistrationResource`

`ModuleRegistry` modified to support `ModuleRegistration`

New functionality: module list, info, register, unregister:
```
cloud-data:>module list
      Source      Processor             Sink         Task
  ----------  --------------------  -----------  --------
      ftp         filter                counter
      http        groovy-filter         log
      time        groovy-transform      redis
                  transform

cloud-data:>module info http --type source
Information about source module 'http':

Maven coordinates:
org.springframework.cloud.stream.module:http-source:jar:1.0.0.BUILD-SNAPSHOT

  Option Name  Description  Default  Type
  -----------  -----------  -------  ----

cloud-data:>module register mainframe --type source --coordinates
com.megacorp.modules:mainframe:2.4
Successfully registered module 'source:mainframe'

cloud-data:>module list
      Source         Processor             Sink         Task
  -------------  --------------------  -----------  --------
      ftp            filter                counter
      http           groovy-filter         log
      mainframe      groovy-transform      redis
      time           transform

cloud-data:>module info mainframe:source
Information about source module 'mainframe':

Maven coordinates: com.megacorp.modules:mainframe:jar:2.4

  Option Name  Description  Default  Type
  -----------  -----------  -------  ----

cloud-data:>module unregister mainframe:source
Successfully unregistered module 'mainframe' with type source
```
Missing functionality:
 * Module options display
 * Module composition