### PR TITLE
Add better YARN application model

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,42 +105,41 @@ $ mvn clean package
 $ hdfs dfs -rm -R /app/app
 ```
 
-4\. start cli app, push and submit app to yarn
+4\. start `spring-cloud-data-admin` with `yarn` profile
+
+```
+$ java -Dspring.profiles.active=yarn -jar spring-cloud-data-admin/target/spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar
+```
+
+5\. start `spring-cloud-data-shell`
+
+```
+$ java -jar spring-cloud-data-shell/target/spring-cloud-data-shell-1.0.0.BUILD-SNAPSHOT.jar
+
+cloud-data:>stream create --name "ticktock" --definition "time --fixedDelay=5|log" --deploy
+
+cloud-data:>stream list
+  Stream Name  Stream Definition        Status
+  -----------  -----------------------  --------
+  ticktock     time --fixedDelay=5|log  deployed
+
+cloud-data:>stream destroy --name "ticktock"
+Destroyed stream 'ticktock'
+```
+
+YARN application is pushed and started automatically during a stream deployment process. This application instance is not automatically closed which can be done from CLI:
 
 ```
 $ java -jar spring-cloud-data-yarn/spring-cloud-data-yarn-client/target/spring-cloud-data-yarn-client-1.0.0.BUILD-SNAPSHOT.jar shell
-Spring YARN Cli (v2.3.0.M1)
+Spring YARN Cli (v2.3.0.M2)
 Hit TAB to complete. Type 'help' and hit RETURN for help, and 'exit' to quit.
-$ push
-New version installed
-$ submit
-New instance submitted with id application_1439285616431_0010
-$ submitted 
-  APPLICATION ID                  USER          NAME                        QUEUE    TYPE  STARTTIME       FINISHTIME  STATE    FINALSTATUS  ORIGINAL TRACKING URL
-  ------------------------------  ------------  --------------------------  -------  ----  --------------  ----------  -------  -----------  --------------------------
-  application_1439285616431_0010  jvalkealahti  spring-cloud-data-yarn-app  default  XD    12/08/15 08:32  N/A         RUNNING  UNDEFINED    http://192.168.122.1:51656
-```
 
-5\. start `spring-cloud-data-rest` with `yarn` profile
+$ submitted
+  APPLICATION ID                  USER          NAME                            QUEUE    TYPE       STARTTIME       FINISHTIME  STATE    FINALSTATUS  ORIGINAL TRACKING URL
+  ------------------------------  ------------  ------------------------------  -------  ---------  --------------  ----------  -------  -----------  --------------------------
+  application_1439803106751_0088  jvalkealahti  spring-cloud-data-yarn-app_app  default  CLOUDDATA  01/09/15 09:02  N/A         RUNNING  UNDEFINED    http://192.168.122.1:48913
 
-```
-$ java -Dspring.profiles.active=yarn -jar spring-cloud-data-rest/target/spring-cloud-data-rest-1.0.0.BUILD-SNAPSHOT.jar
-```
-
-6\. start `spring-cloud-data-shell`
-
-```
-java -jar spring-cloud-data-shell/target/spring-cloud-data-shell-1.0.0.BUILD-SNAPSHOT.jar
-
-cloud-data:>stream create --name ticktock --definition "time|log" --deploy
-Created and deployed new stream 'ticktock'
-
-cloud-data:>stream list
-  Stream Name  Stream Definition  Status
-  -----------  -----------------  --------
-  ticktock     time|log           deployed
-
-cloud-data:>stream destroy --name ticktock
-Destroyed stream 'ticktock'
+$ shutdown -a application_1439803106751_0088
+shutdown requested
 ```
 

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/AdminApplication.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/AdminApplication.java
@@ -17,12 +17,18 @@
 package org.springframework.cloud.data.admin;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.yarn.boot.YarnAppmasterAutoConfiguration;
+import org.springframework.yarn.boot.YarnClientAutoConfiguration;
+import org.springframework.yarn.boot.YarnContainerAutoConfiguration;
 
 /**
  * @author Mark Fisher
  */
 @SpringBootApplication
+@EnableAutoConfiguration(exclude = { YarnClientAutoConfiguration.class, YarnAppmasterAutoConfiguration.class,
+		YarnContainerAutoConfiguration.class })
 public class AdminApplication {
 
 	public static void main(String[] args) throws InterruptedException {

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/LocalCondition.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/LocalCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/YarnConfiguration.java
+++ b/spring-cloud-data-admin/src/main/java/org/springframework/cloud/data/admin/config/YarnConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-admin/src/main/resources/application.yml
+++ b/spring-cloud-data-admin/src/main/resources/application.yml
@@ -7,4 +7,19 @@ security:
     enabled: false
 spring:
   hadoop:
+    fsUri: hdfs://localhost:8020
     resourceManagerHost: localhost
+  yarn:
+    appType: CLOUDDATA
+    appName: spring-cloud-data-yarn-app
+    applicationBaseDir: /app/
+    applicationDir: /app/spring-cloud-data-yarn-app/
+    client:
+      clientClass: org.springframework.yarn.client.DefaultApplicationYarnClient
+      files:
+        - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/target/spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar"
+        - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-container/target/spring-cloud-data-yarn-container-1.0.0.BUILD-SNAPSHOT.jar"
+      launchcontext:
+        archiveFile: spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar
+      resource:
+        memory: 1g

--- a/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/AdminApplicationTests.java
+++ b/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/AdminApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/AdminApplicationTests.java
+++ b/spring-cloud-data-admin/src/test/java/org/springframework/cloud/data/admin/AdminApplicationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.admin;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.cloud.data.module.deployer.local.LocalModuleDeployer;
+import org.springframework.cloud.data.module.deployer.yarn.YarnModuleDeployer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Generic tests for {@link AdminApplication}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class AdminApplicationTests {
+
+	@Test
+	public void testDefaultProfile() {
+		SpringApplication app = new SpringApplication(AdminApplication.class);
+		ConfigurableApplicationContext context = app.run(new String[] { "--server.port=0" });
+		assertThat(context.containsBean("processModuleDeployer"), is(true));
+		assertThat(context.getBean("processModuleDeployer"), instanceOf(LocalModuleDeployer.class));
+		context.close();
+	}
+
+	@Test
+	public void testYarnProfile() {
+		SpringApplication app = new SpringApplication(AdminApplication.class);
+		ConfigurableApplicationContext context = app.run(new String[] { "--spring.profiles.active=yarn",
+				"--server.port=0" });
+		assertThat(context.containsBean("processModuleDeployer"), is(true));
+		assertThat(context.getBean("processModuleDeployer"), instanceOf(YarnModuleDeployer.class));
+		context.close();
+	}
+
+}

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/pom.xml
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-yarn-boot</artifactId>
-			<version>2.2.0.M1</version>
+			<version>2.3.0.M2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -34,6 +34,17 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-module-launcher</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.statemachine</groupId>
+			<artifactId>spring-statemachine-core</artifactId>
+			<version>1.0.0.RC1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.statemachine</groupId>
+			<artifactId>spring-statemachine-test</artifactId>
+			<version>1.0.0.RC1</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/DefaultYarnCloudAppService.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/DefaultYarnCloudAppService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/DefaultYarnCloudAppService.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/DefaultYarnCloudAppService.java
@@ -51,9 +51,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		appProperties.setProperty(PREFIX_YIA + "operation", "PUSHED");
 		app.appProperties(appProperties);
 		String info = app.run();
-		if (logger.isDebugEnabled()) {
-			logger.debug("Full response for PUSHED: " + info);
-		}
+		logger.debug("Full response for PUSHED: {}", info);
 
 		String[] lines = info.split("\\r?\\n");
 		if (lines.length > 2) {
@@ -78,9 +76,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		appProperties.setProperty(PREFIX_YIA + "type", "CLOUDDATA");
 		app.appProperties(appProperties);
 		String info = app.run();
-		if (logger.isDebugEnabled()) {
-			logger.debug("Full response for SUBMITTED: " + info);
-		}
+		logger.debug("Full response for SUBMITTED: {}", info);
 
 		String[] lines = info.split("\\r?\\n");
 		if (lines.length > 2) {
@@ -137,9 +133,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 
 		app.appProperties(appProperties);
 		String output = app.run();
-		if (logger.isDebugEnabled()) {
-			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERCREATE: " + output);
-		}
+		logger.debug("Output from YarnContainerClusterApplication run for CLUSTERCREATE: {}", output);
 	}
 
 	@Override
@@ -151,9 +145,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
 		app.appProperties(appProperties);
 		String output = app.run();
-		if (logger.isDebugEnabled()) {
-			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSTART: " + output);
-		}
+		logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSTART: {}", output);
 	}
 
 	@Override
@@ -165,9 +157,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
 		app.appProperties(appProperties);
 		String output = app.run();
-		if (logger.isDebugEnabled()) {
-			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSTOP: " + output);
-		}
+		logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSTOP: {}", output);
 	}
 
 	@Override
@@ -179,9 +169,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
 		app.appProperties(appProperties);
 		String output = app.run();
-		if (logger.isDebugEnabled()) {
-			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERDESTROY: " + output);
-		}
+		logger.debug("Output from YarnContainerClusterApplication run for CLUSTERDESTROY: {}", output);
 	}
 
 	@Override
@@ -205,9 +193,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		app.appProperties(appProperties);
 		try {
 			String output = app.run();
-			if (logger.isDebugEnabled()) {
-				logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSINFO: " + output);
-			}
+			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSINFO: {}", output);
 			String[] lines = output.split("\\r?\\n");
 			for (int i = 2; i < lines.length; i++) {
 				String[] fields = lines[i].trim().split("\\s+");
@@ -230,9 +216,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService {
 		app.appProperties(appProperties);
 		try {
 			String output = app.run();
-			if (logger.isDebugEnabled()) {
-				logger.debug("Output from YarnContainerClusterApplication run for CLUSTERINFO: " + output);
-			}
+			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERINFO: {}", output);
 
 			String[] lines = output.trim().split("\\r?\\n");
 			if (lines.length == 3) {

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/DefaultYarnCloudAppService.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/DefaultYarnCloudAppService.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.deployer.yarn;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.boot.app.YarnContainerClusterApplication;
+import org.springframework.yarn.boot.app.YarnInfoApplication;
+import org.springframework.yarn.boot.app.YarnPushApplication;
+import org.springframework.yarn.boot.app.YarnSubmitApplication;
+
+/**
+ * Default implementation of {@link YarnCloudAppService} which talks to
+ * rest api's exposed by specific yarn controlling container clusters.
+ *
+ * @author Janne Valkealahti
+ */
+public class DefaultYarnCloudAppService implements YarnCloudAppService {
+
+	private static final Logger logger = LoggerFactory.getLogger(DefaultYarnCloudAppService.class);
+	private static final String PREFIX_YIA = "spring.yarn.internal.YarnInfoApplication.";
+	private static final String PREFIX_CCA = "spring.yarn.internal.ContainerClusterApplication.";
+
+	@Override
+	public Collection<CloudAppInfo> getApplications() {
+		ArrayList<CloudAppInfo> infos = new ArrayList<CloudAppInfo>();
+
+		YarnInfoApplication app = new YarnInfoApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_YIA + "operation", "PUSHED");
+		app.appProperties(appProperties);
+		String info = app.run();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Full response for PUSHED: " + info);
+		}
+
+		String[] lines = info.split("\\r?\\n");
+		if (lines.length > 2) {
+			for (int i = 2; i < lines.length; i++) {
+				String[] fields = lines[i].trim().split("\\s+");
+				if (fields.length > 1) {
+					infos.add(new CloudAppInfo(fields[0].trim()));
+				}
+			}
+		}
+		return infos;
+	}
+
+	@Override
+	public Collection<CloudAppInstanceInfo> getInstances() {
+		ArrayList<CloudAppInstanceInfo> infos = new ArrayList<CloudAppInstanceInfo>();
+
+		YarnInfoApplication app = new YarnInfoApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_YIA + "operation", "SUBMITTED");
+		appProperties.setProperty(PREFIX_YIA + "verbose", "false");
+		appProperties.setProperty(PREFIX_YIA + "type", "CLOUDDATA");
+		app.appProperties(appProperties);
+		String info = app.run();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Full response for SUBMITTED: " + info);
+		}
+
+		String[] lines = info.split("\\r?\\n");
+		if (lines.length > 2) {
+			for (int i = 2; i < lines.length; i++) {
+				String[] fields = lines[i].trim().split("\\s+");
+				if (fields.length > 10) {
+					infos.add(new CloudAppInstanceInfo(fields[0].trim(), fields[2].trim(), fields[fields.length - 1]
+							.trim()));
+				}
+			}
+		}
+		return infos;
+	}
+
+	@Override
+	public void pushApplication(String appVersion) {
+		YarnPushApplication app = new YarnPushApplication();
+		app.applicationVersion(appVersion);
+		Properties instanceProperties = new Properties();
+		instanceProperties.setProperty("spring.yarn.applicationVersion", appVersion);
+		app.configFile("application.properties", instanceProperties);
+		app.run();
+	}
+
+	@Override
+	public String submitApplication(String appVersion) {
+		String appName = "spring-cloud-data-yarn-app_" + appVersion;
+		YarnSubmitApplication app = new YarnSubmitApplication();
+		if (StringUtils.hasText(appName)) {
+			app.applicationName(appName);
+		}
+		app.applicationVersion(appVersion);
+		return app.run().toString();
+	}
+
+	@Override
+	public void createCluster(String yarnApplicationId, String clusterId, int count, String module,
+			Map<String, String> definitionParameters) {
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_CCA + "operation", "CLUSTERCREATE");
+		appProperties.setProperty(PREFIX_CCA + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
+		appProperties.setProperty(PREFIX_CCA + "clusterDef", "module-template");
+		appProperties.setProperty(PREFIX_CCA + "projectionType", "default");
+		appProperties.setProperty(PREFIX_CCA + "projectionData.any", Integer.toString(count));
+		appProperties.setProperty(PREFIX_CCA + "extraProperties.containerModules", module);
+
+		int i = 0;
+		for (Map.Entry<String, String> entry : definitionParameters.entrySet()) {
+			appProperties.setProperty(PREFIX_CCA + "extraProperties.containerArg" + i++ ,
+					entry.getKey() + "=" + entry.getValue());
+		}
+
+		app.appProperties(appProperties);
+		String output = app.run();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERCREATE: " + output);
+		}
+	}
+
+	@Override
+	public void startCluster(String yarnApplicationId, String clusterId) {
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_CCA + "operation", "CLUSTERSTART");
+		appProperties.setProperty(PREFIX_CCA + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		String output = app.run();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSTART: " + output);
+		}
+	}
+
+	@Override
+	public void stopCluster(String yarnApplicationId, String clusterId) {
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_CCA + "operation", "CLUSTERSTOP");
+		appProperties.setProperty(PREFIX_CCA + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		String output = app.run();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSTOP: " + output);
+		}
+	}
+
+	@Override
+	public void destroyCluster(String yarnApplicationId, String clusterId) {
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_CCA + "operation", "CLUSTERDESTROY");
+		appProperties.setProperty(PREFIX_CCA + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		String output = app.run();
+		if (logger.isDebugEnabled()) {
+			logger.debug("Output from YarnContainerClusterApplication run for CLUSTERDESTROY: " + output);
+		}
+	}
+
+	@Override
+	public Map<String, String> getClustersStates() {
+		HashMap<String, String> states = new HashMap<String, String>();
+		for (CloudAppInstanceInfo instanceInfo : getInstances()) {
+			for (String cluster : getClusters(instanceInfo.getApplicationId())) {
+				states.putAll(getInstanceClustersStates(instanceInfo.getApplicationId(), cluster));
+			}
+		}
+		return states;
+	}
+
+	@Override
+	public Collection<String> getClusters(String yarnApplicationId) {
+		ArrayList<String> clusters = new ArrayList<String>();
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_CCA + "operation", "CLUSTERSINFO");
+		appProperties.setProperty(PREFIX_CCA + "applicationId", yarnApplicationId);
+		app.appProperties(appProperties);
+		try {
+			String output = app.run();
+			if (logger.isDebugEnabled()) {
+				logger.debug("Output from YarnContainerClusterApplication run for CLUSTERSINFO: " + output);
+			}
+			String[] lines = output.split("\\r?\\n");
+			for (int i = 2; i < lines.length; i++) {
+				String[] fields = lines[i].trim().split("\\s+");
+				clusters.add(fields[0]);
+			}
+		} catch (Exception e) {
+			logger.warn("CLUSTERSINFO resulted an error", e);
+		}
+		return clusters;
+	}
+
+	private Map<String, String> getInstanceClustersStates(String yarnApplicationId, String clusterId) {
+		HashMap<String, String> states = new HashMap<String, String>();
+		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
+		Properties appProperties = new Properties();
+		appProperties.setProperty(PREFIX_CCA + "operation", "CLUSTERINFO");
+		appProperties.setProperty(PREFIX_CCA + "applicationId", yarnApplicationId);
+		appProperties.setProperty(PREFIX_CCA + "verbose", "false");
+		appProperties.setProperty(PREFIX_CCA + "clusterId", clusterId);
+		app.appProperties(appProperties);
+		try {
+			String output = app.run();
+			if (logger.isDebugEnabled()) {
+				logger.debug("Output from YarnContainerClusterApplication run for CLUSTERINFO: " + output);
+			}
+
+			String[] lines = output.trim().split("\\r?\\n");
+			if (lines.length == 3) {
+				String[] fields = lines[2].trim().split("\\s+");
+				states.put(clusterId, fields[0].trim());
+			}
+		} catch (Exception e) {
+			logger.warn("CLUSTERINFO resulted an error", e);
+		}
+		return states;
+	}
+
+}

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppService.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppService.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppService.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.deployer.yarn;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Interface used to glue a state machine and yarn application logic together.
+ *
+ * @author Janne Valkealahti
+ */
+public interface YarnCloudAppService {
+
+	/**
+	 * Get applications pushed to hdfs.
+	 *
+	 * @return the applications
+	 */
+	Collection<CloudAppInfo> getApplications();
+
+	/**
+	 * Get running application instances.
+	 *
+	 * @return the instances
+	 */
+	Collection<CloudAppInstanceInfo> getInstances();
+
+	/**
+	 * Push new application into hdfs.
+	 *
+	 * @param appVersion the app version
+	 */
+	void pushApplication(String appVersion);
+
+	/**
+	 * Submit new application instance into yarn.
+	 *
+	 * @param appVersion the app version
+	 * @return the application id
+	 */
+	String submitApplication(String appVersion);
+
+	/**
+	 * Creates the container cluster.
+	 *
+	 * @param yarnApplicationId the yarn application id
+	 * @param clusterId the cluster id
+	 * @param count the count
+	 * @param module the module
+	 * @param definitionParameters the definition parameters
+	 */
+	void createCluster(String yarnApplicationId, String clusterId, int count, String module,
+			Map<String, String> definitionParameters);
+
+	/**
+	 * Start a container cluster.
+	 *
+	 * @param yarnApplicationId the yarn application id
+	 * @param clusterId the cluster id
+	 */
+	void startCluster(String yarnApplicationId, String clusterId);
+
+	/**
+	 * Stop a container cluster.
+	 *
+	 * @param yarnApplicationId the yarn application id
+	 * @param clusterId the cluster id
+	 */
+	void stopCluster(String yarnApplicationId, String clusterId);
+
+	/**
+	 * Gets the clusters states.
+	 *
+	 * @return the clusters states
+	 */
+	Map<String, String> getClustersStates();
+
+	/**
+	 * Gets the clusters.
+	 *
+	 * @param yarnApplicationId the yarn application id
+	 * @return the clusters
+	 */
+	Collection<String> getClusters(String yarnApplicationId);
+
+	/**
+	 * Destroy cluster.
+	 *
+	 * @param yarnApplicationId the yarn application id
+	 * @param clusterId the cluster id
+	 */
+	void destroyCluster(String yarnApplicationId, String clusterId);
+
+	/**
+	 * Wrapping info about application pushed into hdfs.
+	 */
+	public class CloudAppInfo {
+
+		private final String name;
+
+		public CloudAppInfo(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+	}
+
+	/**
+	 * Wrapping info about running application.
+	 */
+	public class CloudAppInstanceInfo {
+
+		private final String applicationId;
+		private final String name;
+		private final String address;
+
+		public CloudAppInstanceInfo(String applicationId, String name, String address) {
+			this.applicationId = applicationId;
+			this.name = name;
+			this.address = address;
+		}
+
+		public String getApplicationId() {
+			return applicationId;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getAddress() {
+			return address;
+		}
+
+	}
+
+}

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppService.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppService.java
@@ -41,14 +41,17 @@ public interface YarnCloudAppService {
 	Collection<CloudAppInstanceInfo> getInstances();
 
 	/**
-	 * Push new application into hdfs.
+	 * Push new application into hdfs. Push operation is copying needed
+	 * files into hdfs without trying to start a new application instance.
 	 *
 	 * @param appVersion the app version
 	 */
 	void pushApplication(String appVersion);
 
 	/**
-	 * Submit new application instance into yarn.
+	 * Submit new application instance into yarn. Prior to calling a new
+	 * submit operation, application has to exist in hdfs which can be done
+	 * i.e. using {@link #pushApplication(String)} method.
 	 *
 	 * @param appVersion the app version
 	 * @return the application id
@@ -84,7 +87,9 @@ public interface YarnCloudAppService {
 	void stopCluster(String yarnApplicationId, String clusterId);
 
 	/**
-	 * Gets the clusters states.
+	 * Gets the clusters states. Returned map has a mapping between
+	 * yarn container cluster id and its state known by application master
+	 * using container clusters.
 	 *
 	 * @return the clusters states
 	 */

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachine.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachine.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachine.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.deployer.yarn;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.cloud.data.module.deployer.yarn.YarnCloudAppService.CloudAppInfo;
+import org.springframework.cloud.data.module.deployer.yarn.YarnCloudAppService.CloudAppInstanceInfo;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.config.StateMachineBuilder;
+import org.springframework.statemachine.config.StateMachineBuilder.Builder;
+import org.springframework.statemachine.guard.Guard;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Class keeping all {@link StateMachine} logic in one place and is used
+ * to dynamically build a machine.
+ *
+ * @author Janne Valkealahti
+ */
+public class YarnCloudAppStateMachine {
+
+	static final String VAR_APP_VERSION = "appVersion";
+	static final String VAR_APPLICATION_ID = "applicationId";
+	static final String HEADER_APP_VERSION = "appVersion";
+	static final String HEADER_CLUSTER_ID = "clusterId";
+	static final String HEADER_COUNT = "count";
+	static final String HEADER_MODULE = "module";
+	static final String HEADER_DEFINITION_PARAMETERS = "definitionParameters";
+	static final String HEADER_ERROR = "error";
+
+	private final YarnCloudAppService yarnCloudAppService;
+	private final TaskExecutor taskExecutor;
+
+	/**
+	 * Instantiates a new yarn cloud app state machine.
+	 *
+	 * @param yarnCloudAppService the yarn cloud app service
+	 * @param taskExecutor the task executor
+	 */
+	public YarnCloudAppStateMachine(YarnCloudAppService yarnCloudAppService, TaskExecutor taskExecutor) {
+		Assert.notNull(yarnCloudAppService, "YarnCloudAppService must be set");
+		Assert.notNull(taskExecutor, "TaskExecutor must be set");
+		this.yarnCloudAppService = yarnCloudAppService;
+		this.taskExecutor = taskExecutor;
+	}
+
+	/**
+	 * Builds the state machine and instructs it to start automatically.
+	 *
+	 * @return the state machine
+	 * @throws Exception the exception
+	 */
+	public StateMachine<States, Events> buildStateMachine() throws Exception {
+		return buildStateMachine(true);
+	}
+
+	/**
+	 * Builds the state machine.
+	 *
+	 * @param autoStartup the auto startup
+	 * @return the state machine
+	 * @throws Exception the exception
+	 */
+	public StateMachine<States, Events> buildStateMachine(boolean autoStartup) throws Exception {
+		Builder<States, Events> builder = StateMachineBuilder.builder();
+
+		builder.configureConfiguration()
+			.withConfiguration()
+				.autoStartup(autoStartup)
+				.taskExecutor(taskExecutor);
+
+		builder.configureStates()
+			.withStates()
+				.initial(States.READY)
+				.state(States.ERROR)
+				.state(States.DEPLOYMODULE, new ResetVariablesAction(), null)
+				.state(States.DEPLOYMODULE, Events.DEPLOY, Events.UNDEPLOY)
+				.state(States.UNDEPLOYMODULE, new ResetVariablesAction(), null)
+				.state(States.UNDEPLOYMODULE, Events.DEPLOY, Events.UNDEPLOY)
+				.and()
+				.withStates()
+					.parent(States.DEPLOYMODULE)
+					.initial(States.CHECKAPP)
+					.state(States.CHECKAPP, new CheckAppAction(), null)
+					.choice(States.PUSHAPPCHOICE)
+					.state(States.PUSHAPP, new PushAppAction(), null)
+					.state(States.CHECKINSTANCE, new CheckInstanceAction(), null)
+					.choice(States.STARTINSTANCECHOICE)
+					.state(States.STARTINSTANCE, new StartInstanceAction(), null)
+					.state(States.CREATECLUSTER, new CreateClusterAction(), null)
+					.state(States.STARTCLUSTER, new StartClusterAction(), null)
+					.and()
+				.withStates()
+					.parent(States.UNDEPLOYMODULE)
+					.initial(States.STOPCLUSTER)
+					.state(States.STOPCLUSTER, new StopClusterAction(), null)
+					.state(States.DESTROYCLUSTER, new DestroyClusterAction(), null);
+
+		builder.configureTransitions()
+			.withExternal()
+				.source(States.DEPLOYMODULE).target(States.ERROR)
+				.event(Events.ERROR)
+				.and()
+			.withExternal()
+				.source(States.DEPLOYMODULE).target(States.READY)
+				.event(Events.CONTINUE)
+				.and()
+			.withExternal()
+				.source(States.UNDEPLOYMODULE).target(States.READY)
+				.event(Events.CONTINUE)
+				.and()
+			.withExternal()
+				.source(States.READY).target(States.DEPLOYMODULE)
+				.event(Events.DEPLOY)
+				.and()
+			.withExternal()
+				.source(States.READY).target(States.UNDEPLOYMODULE)
+				.event(Events.UNDEPLOY)
+				.and()
+			.withExternal()
+				.source(States.CHECKAPP).target(States.PUSHAPPCHOICE)
+				.and()
+			.withChoice()
+				.source(States.PUSHAPPCHOICE)
+				.first(States.PUSHAPP, new PushAppGuard())
+				.last(States.CHECKINSTANCE)
+				.and()
+			.withExternal()
+				.source(States.PUSHAPP).target(States.CHECKINSTANCE)
+				.and()
+			.withExternal()
+				.source(States.CHECKINSTANCE).target(States.STARTINSTANCECHOICE)
+				.and()
+			.withChoice()
+				.source(States.STARTINSTANCECHOICE)
+				.first(States.STARTINSTANCE, new StartInstanceGuard())
+				.last(States.CREATECLUSTER)
+				.and()
+			.withExternal()
+				.source(States.STARTINSTANCE).target(States.CREATECLUSTER)
+				.and()
+			.withExternal()
+				.source(States.CREATECLUSTER).target(States.STARTCLUSTER)
+				.and()
+			.withExternal()
+				.source(States.STOPCLUSTER).target(States.DESTROYCLUSTER);
+
+		return builder.build();
+	}
+
+	/**
+	 * {@link Action} which clears existing extended state variables.
+	 */
+	private class ResetVariablesAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			context.getExtendedState().getVariables().clear();
+		}
+	}
+
+	/**
+	 * {@link Action} which queries {@link YarnCloudAppService} and checks if
+	 * passed {@code appVersion} from event headers exists and sends {@code ERROR}
+	 * event into state machine if it doesn't exist. Add to be used {@code appVersion}
+	 * into extended state variables which later used by other guards and actions.
+	 */
+	private class CheckAppAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			String appVersion = (String) context.getMessageHeader(HEADER_APP_VERSION);
+
+			if (!StringUtils.hasText(appVersion)) {
+				context.getStateMachine().sendEvent(
+						MessageBuilder.withPayload(Events.ERROR).setHeader(HEADER_ERROR, "appVersion not defined")
+								.build());
+			} else {
+				Collection<CloudAppInfo> appInfos = yarnCloudAppService.getApplications();
+				for (CloudAppInfo appInfo : appInfos) {
+					if (appInfo.getName().equals(appVersion)) {
+						context.getExtendedState().getVariables().put(VAR_APP_VERSION, appVersion);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * {@link Guard} which is used to protect state where application push
+	 * into hdfs would happen. Assumes that if {@code appVersion} variable
+	 * exists, application is installed.
+	 */
+	private class PushAppGuard implements Guard<States, Events> {
+
+		@Override
+		public boolean evaluate(StateContext<States, Events> context) {
+			return !context.getExtendedState().getVariables().containsKey(VAR_APP_VERSION);
+		}
+	}
+
+	/**
+	 * {@link Action} which pushes application version into hdfs found
+	 * from variable {@code appVersion}.
+	 */
+	private class PushAppAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			String appVersion = (String) context.getMessageHeader(HEADER_APP_VERSION);
+			yarnCloudAppService.pushApplication(appVersion);
+		}
+	}
+
+	/**
+	 * {@link Action} which queries {@link YarnCloudAppService} for existing
+	 * running instances.
+	 */
+	private class CheckInstanceAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			Collection<CloudAppInstanceInfo> appInstanceInfos = yarnCloudAppService.getInstances();
+			for (CloudAppInstanceInfo appInstanceInfo : appInstanceInfos) {
+				if (appInstanceInfo.getAddress().contains("http")) {
+					context.getExtendedState().getVariables().put(VAR_APPLICATION_ID, appInstanceInfo.getApplicationId());
+					break;
+				}
+			}
+
+		}
+	}
+
+	/**
+	 * {@link Guard} which protects state {@code STARTINSTANCE} in choice state
+	 * {@code STARTINSTANCECHOICE}.
+	 */
+	private class StartInstanceGuard implements Guard<States, Events> {
+
+		@Override
+		public boolean evaluate(StateContext<States, Events> context) {
+			return !context.getExtendedState().getVariables().containsKey(VAR_APPLICATION_ID);
+		}
+	}
+
+	/**
+	 * {@link Action} which launches new application instance.
+	 */
+	private class StartInstanceAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			String appVersion = (String) context.getMessageHeader(HEADER_APP_VERSION);
+			String applicationId = yarnCloudAppService.submitApplication(appVersion);
+			context.getExtendedState().getVariables().put(VAR_APPLICATION_ID, applicationId);
+
+			for (int i = 0; i < 60; i++) {
+				if (isRunning()) {
+					return;
+				}
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+				}
+			}
+			// TODO: we don't yet handle errors
+			context.getStateMachine().sendEvent(
+					MessageBuilder.withPayload(Events.ERROR).setHeader(HEADER_ERROR, "failed starting app").build());
+		}
+
+		private boolean isRunning() {
+			for (CloudAppInstanceInfo instanceInfo : yarnCloudAppService.getInstances()) {
+				if (instanceInfo.getAddress().contains("http")) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * {@link Action} which creates a new container cluster.
+	 */
+	private class CreateClusterAction implements Action<States, Events> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			yarnCloudAppService.createCluster(context.getExtendedState().get(VAR_APPLICATION_ID, String.class), context
+					.getMessageHeaders().get(HEADER_CLUSTER_ID, String.class),
+					context.getMessageHeaders().get(HEADER_COUNT, Integer.class),
+					context.getMessageHeaders().get(HEADER_MODULE, String.class),
+					context.getMessageHeaders().get(HEADER_DEFINITION_PARAMETERS, Map.class));
+		}
+	}
+
+	/**
+	 * {@link Action} which starts existing container cluster.
+	 */
+	private class StartClusterAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			yarnCloudAppService.startCluster(context.getExtendedState().get(VAR_APPLICATION_ID, String.class), context
+					.getMessageHeaders().get(HEADER_CLUSTER_ID, String.class));
+			context.getStateMachine().sendEvent(Events.CONTINUE);
+		}
+	}
+
+	/**
+	 * {@link Action} which stops existing container cluster.
+	 */
+	private class StopClusterAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			String clusterId = context.getMessageHeaders().get(HEADER_CLUSTER_ID, String.class);
+			for (CloudAppInstanceInfo instanceInfo : yarnCloudAppService.getInstances()) {
+				for (String cluster : yarnCloudAppService.getClusters(instanceInfo.getApplicationId())) {
+					if (cluster.equals(clusterId)) {
+						yarnCloudAppService.stopCluster(instanceInfo.getApplicationId(), clusterId);
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * {@link Action} which destroys existing container cluster.
+	 */
+	private class DestroyClusterAction implements Action<States, Events> {
+
+		@Override
+		public void execute(StateContext<States, Events> context) {
+			String clusterId = context.getMessageHeaders().get(HEADER_CLUSTER_ID, String.class);
+			for (CloudAppInstanceInfo instanceInfo : yarnCloudAppService.getInstances()) {
+				for (String cluster : yarnCloudAppService.getClusters(instanceInfo.getApplicationId())) {
+					if (cluster.equals(clusterId)) {
+						yarnCloudAppService.destroyCluster(instanceInfo.getApplicationId(), clusterId);
+						context.getStateMachine().sendEvent(Events.CONTINUE);
+						return;
+					}
+				}
+			}
+			context.getStateMachine().sendEvent(Events.CONTINUE);
+		}
+	}
+
+	/**
+	 * Enumeration of module handling states.
+	 */
+	public enum States {
+
+		/** Main state where machine is ready for either deploy or undeploy requests. */
+		READY,
+
+		/** State where possible errors are handled. */
+		ERROR,
+
+		/** Super state of all other states handling deployment. */
+		DEPLOYMODULE,
+
+		/** State where app presence in hdfs is checked. */
+		CHECKAPP,
+
+		/** Pseudostate where choice to enter {@code PUSHAPP} is made. */
+		PUSHAPPCHOICE,
+
+		/** State where application is pushed into hdfs. */
+		PUSHAPP,
+
+		/** State where app instance running status is checked. */
+		CHECKINSTANCE,
+
+		/** Pseudostate where choice to enter {@code STARTINSTANCE} is made. */
+		STARTINSTANCECHOICE,
+
+		/** State where app instance is started. */
+		STARTINSTANCE,
+
+		/** State where container cluster is created. */
+		CREATECLUSTER,
+
+		/** State where container cluster is started. */
+		STARTCLUSTER,
+
+		/** Super state of all other states handling undeployment. */
+		UNDEPLOYMODULE,
+
+		/** State where container cluster is stopped. */
+		STOPCLUSTER,
+
+		/** State where container cluster is destroyed. */
+		DESTROYCLUSTER;
+	}
+
+	/**
+	 * Enumeration of module handling events.
+	 */
+	public enum Events {
+
+		/** Event indicating that machine should handle deploy request. */
+		DEPLOY,
+
+		/** Event indicating that machine should handle undeploy request. */
+		UNDEPLOY,
+
+		/** Event indicating that machine should move into error handling logic. */
+		ERROR,
+
+		/** Event indicating that machine should move back into ready state. */
+		CONTINUE
+	}
+
+}

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
@@ -16,11 +16,9 @@
 
 package org.springframework.cloud.data.module.deployer.yarn;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
+import java.util.Map.Entry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,9 +28,11 @@ import org.springframework.cloud.data.core.ModuleDeploymentId;
 import org.springframework.cloud.data.core.ModuleDeploymentRequest;
 import org.springframework.cloud.data.module.ModuleStatus;
 import org.springframework.cloud.data.module.deployer.ModuleDeployer;
-import org.springframework.util.StringUtils;
-import org.springframework.yarn.boot.app.YarnContainerClusterApplication;
-import org.springframework.yarn.boot.app.YarnInfoApplication;
+import org.springframework.cloud.data.module.deployer.yarn.YarnCloudAppStateMachine.Events;
+import org.springframework.cloud.data.module.deployer.yarn.YarnCloudAppStateMachine.States;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateMachine;
 
 /**
  * {@link ModuleDeployer} which communicates with a Yarn app running
@@ -47,9 +47,18 @@ import org.springframework.yarn.boot.app.YarnInfoApplication;
 public class YarnModuleDeployer implements ModuleDeployer {
 
 	private static final Logger logger = LoggerFactory.getLogger(YarnModuleDeployer.class);
-	private static final String PREFIX = "spring.yarn.internal.ContainerClusterApplication.";
+	private final YarnCloudAppService yarnCloudAppService;
+	private final StateMachine<States, Events> stateMachine;
 
-	public YarnModuleDeployer() {
+	/**
+	 * Instantiates a new yarn module deployer.
+	 *
+	 * @param yarnCloudAppService the yarn cloud app service
+	 * @param stateMachine the state machine
+	 */
+	public YarnModuleDeployer(YarnCloudAppService yarnCloudAppService, StateMachine<States, Events> stateMachine) {
+		this.yarnCloudAppService = yarnCloudAppService;
+		this.stateMachine = stateMachine;
 	}
 
 	@Override
@@ -57,157 +66,68 @@ public class YarnModuleDeployer implements ModuleDeployer {
 		int count = request.getCount();
 		ModuleCoordinates coordinates = request.getCoordinates();
 		ModuleDefinition definition = request.getDefinition();
-		logger.info("deploying request for definition: " + definition);
-
-		ModuleDeploymentId moduleDeploymentId = ModuleDeploymentId.fromModuleDefinition(definition);
-		String clusterId = sanitizeClusterId(convertFromModuleDeploymentId(moduleDeploymentId));
-
-		String yarnApplicationId = findRunningCloudDataYarnApp();
-		logger.info("Using application id " + yarnApplicationId);
+		ModuleDeploymentId id = ModuleDeploymentId.fromModuleDefinition(definition);
+		String clusterId = moduleDeploymentIdToClusterId(id);
 		String module = coordinates.toString();
-		logger.info("deploying module: " + module);
-
 		Map<String, String> definitionParameters = definition.getParameters();
 		Map<String, String> deploymentProperties = request.getDeploymentProperties();
+
+		logger.info("deploying request for definition: " + definition);
+		logger.info("deploying module: " + module);
 		logger.info("definitionParameters: " + definitionParameters);
 		logger.info("deploymentProperties: " + deploymentProperties);
 
-		// Using same app instance yarn boot cli is using to
-		// communicate with an app running on yarn via its boot actuator
-		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
-		Properties appProperties = new Properties();
-		appProperties.setProperty(PREFIX + "operation", "CLUSTERCREATE");
-		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
-		appProperties.setProperty(PREFIX + "clusterId", clusterId);
-		appProperties.setProperty(PREFIX + "clusterDef", "module-template");
-		appProperties.setProperty(PREFIX + "projectionType", "default");
-		appProperties.setProperty(PREFIX + "projectionData.any", Integer.toString(count));
-		appProperties.setProperty(PREFIX + "extraProperties.containerModules", module);
-		app.appProperties(appProperties);
-		String output = app.run();
-		logger.info("Output from YarnContainerClusterApplication run for CLUSTERCREATE: " + output);
+		// TODO: using default app name "app" until we start to customise
+		//       via deploymentProperties
+		Message<Events> message = MessageBuilder.withPayload(Events.DEPLOY)
+				.setHeader(YarnCloudAppStateMachine.HEADER_APP_VERSION, "app")
+				.setHeader(YarnCloudAppStateMachine.HEADER_CLUSTER_ID, clusterId)
+				.setHeader(YarnCloudAppStateMachine.HEADER_COUNT, count)
+				.setHeader(YarnCloudAppStateMachine.HEADER_MODULE, module)
+				.setHeader(YarnCloudAppStateMachine.HEADER_DEFINITION_PARAMETERS, definitionParameters)
+				.build();
 
-		app = new YarnContainerClusterApplication();
-		appProperties = new Properties();
-		appProperties.setProperty(PREFIX + "operation", "CLUSTERSTART");
-		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
-		appProperties.setProperty(PREFIX + "clusterId", clusterId);
-		app.appProperties(appProperties);
-		output = app.run();
-		logger.info("Output from YarnContainerClusterApplication run for CLUSTERSTART: " + output);
-
-		return moduleDeploymentId;
+		stateMachine.sendEvent(message);
+		return id;
 	}
 
 	@Override
 	public void undeploy(ModuleDeploymentId id) {
-		String clusterId = convertFromModuleDeploymentId(id);
-		String yarnApplicationId = findRunningCloudDataYarnApp();
-		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
-		Properties appProperties = new Properties();
-		appProperties.setProperty(PREFIX + "operation", "CLUSTERSTOP");
-		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
-		appProperties.setProperty(PREFIX + "clusterId", clusterId);
-		app.appProperties(appProperties);
-		String output = app.run();
-		logger.info("Output from YarnContainerClusterApplication run for CLUSTERSTOP: " + output);
+		String clusterId = moduleDeploymentIdToClusterId(id);
+		Message<Events> message = MessageBuilder.withPayload(Events.UNDEPLOY)
+				.setHeader(YarnCloudAppStateMachine.HEADER_CLUSTER_ID, clusterId)
+				.build();
+		stateMachine.sendEvent(message);
 	}
 
 	@Override
 	public ModuleStatus status(ModuleDeploymentId id) {
-		String yarnApplicationId = findRunningCloudDataYarnApp();
-		String clusterId = convertFromModuleDeploymentId(id);
-
-		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
-		Properties appProperties = new Properties();
-		appProperties.setProperty(PREFIX + "operation", "CLUSTERINFO");
-		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
-		appProperties.setProperty(PREFIX + "verbose", "false");
-		appProperties.setProperty(PREFIX + "clusterId", clusterId);
-		app.appProperties(appProperties);
-		String info = app.run();
-		logger.info("Output from YarnContainerClusterApplication run for CLUSTERINFO: " + info);
-
-		boolean deployed = false;
-		String[] lines = info.trim().split("\\r?\\n");
-		if (lines.length == 3 && lines[2].contains("RUNNING")) {
-			deployed = true;
-		}
-
-		YarnModuleInstanceStatus status = new YarnModuleInstanceStatus(id.toString(), deployed, null);
-		return ModuleStatus.of(id).with(status).build();
+		return status().get(id);
 	}
 
 	@Override
 	public Map<ModuleDeploymentId, ModuleStatus> status() {
 		HashMap<ModuleDeploymentId, ModuleStatus> statuses = new HashMap<ModuleDeploymentId, ModuleStatus>();
-		for (String clusterId : findRunningContainerClusters()) {
-			ModuleDeploymentId moduleDeploymentId = convertToModuleDeploymentId(clusterId);
-			statuses.put(moduleDeploymentId, status(moduleDeploymentId));
+		for (Entry<String, String> entry : yarnCloudAppService.getClustersStates().entrySet()) {
+			ModuleDeploymentId id = clusterIdToModuleDeploymentId(entry.getKey());
+			YarnModuleInstanceStatus status = new YarnModuleInstanceStatus(id.toString(), entry
+					.getValue().equals("RUNNING"), null);
+			statuses.put(id, ModuleStatus.of(id).with(status).build());
 		}
 		return statuses;
 	}
 
-	private static String findRunningCloudDataYarnApp() {
-		YarnInfoApplication app = new YarnInfoApplication();
-		Properties appProperties = new Properties();
-		appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.operation", "SUBMITTED");
-		appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.verbose", "false");
-		appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.type", "CLOUDDATA");
-		app.appProperties(appProperties);
-		String info = app.run();
-		logger.info("Full status response for SUBMITTED app " + info);
-
-		// TODO: either make this easier in YarnInfoApplication
-		//       or use rest api directly
-		String[] lines = info.split("\\r?\\n");
-		logger.info("Parsing application id from " + StringUtils.arrayToCommaDelimitedString(lines));
-		if (lines.length == 3) {
-			return lines[2].trim().split("\\s+")[0].trim();
-		} else {
-			return null;
-		}
+	private static String moduleDeploymentIdToClusterId(ModuleDeploymentId id) {
+		return id.getGroup() + ":" + id.getLabel();
 	}
 
-	private static Collection<String> findRunningContainerClusters() {
-		String yarnApplicationId = findRunningCloudDataYarnApp();
-
-		YarnContainerClusterApplication app = new YarnContainerClusterApplication();
-		Properties appProperties = new Properties();
-		appProperties.setProperty(PREFIX + "operation", "CLUSTERSINFO");
-		appProperties.setProperty(PREFIX + "applicationId", yarnApplicationId);
-		app.appProperties(appProperties);
-		String info = app.run();
-		logger.info("Output from YarnContainerClusterApplication run for CLUSTERSINFO: " + info);
-
-		ArrayList<String> ids = new ArrayList<String>();
-		String[] lines = info.split("\\r?\\n");
-		if (lines.length > 2) {
-			for (int i = 2; i < lines.length; i++) {
-				ids.add(lines[i].trim());
-			}
-		}
-		return ids;
-	}
-
-	private static String convertFromModuleDeploymentId(ModuleDeploymentId moduleDeploymentId) {
-		return moduleDeploymentId.getGroup() + ":" + moduleDeploymentId.getLabel();
-	}
-
-	private static ModuleDeploymentId convertToModuleDeploymentId(String containerClusterName) {
-		String[] split = containerClusterName.split(":");
+	private static ModuleDeploymentId clusterIdToModuleDeploymentId(String clusterId) {
+		String[] split = clusterId.split(":");
 		if (split.length == 2) {
 			return new ModuleDeploymentId(split[0], split[1]);
 		} else {
-			return null;
+			throw new IllegalArgumentException("Invalid clusterId=[" + clusterId + "]");
 		}
-	}
-
-	private static String sanitizeClusterId(String clusterId) {
-		// spring yarn bug which treats postfix after dot
-		// as file delimiter and removes it per default mvc
-		// feature. need to handle this in shdp
-		return clusterId.replaceAll("\\.", "_");
 	}
 
 }

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleInstanceStatus.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleInstanceStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/test/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachineTests.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/test/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachineTests.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.data.module.deployer.yarn;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.springframework.cloud.data.module.deployer.yarn.YarnCloudAppStateMachine.Events;
+import org.springframework.cloud.data.module.deployer.yarn.YarnCloudAppStateMachine.States;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.listener.StateMachineListenerAdapter;
+import org.springframework.statemachine.state.State;
+import org.springframework.statemachine.test.StateMachineTestPlan;
+import org.springframework.statemachine.test.StateMachineTestPlanBuilder;
+
+/**
+ * Tests for {@link StateMachine} which is controlling
+ * module deployment logic with YARN applications.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnCloudAppStateMachineTests {
+
+	@Test
+	public void testInitial() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
+		TestYarnCloudAppService yarnCloudAppService = new TestYarnCloudAppService();
+		TaskExecutor taskExecutor = context.getBean(TaskExecutor.class);
+		YarnCloudAppStateMachine ycasm = new YarnCloudAppStateMachine(yarnCloudAppService, taskExecutor);
+		StateMachine<States, Events> stateMachine = ycasm.buildStateMachine(false);
+
+		StateMachineTestPlan<States, Events> plan =
+				StateMachineTestPlanBuilder.<States, Events>builder()
+					.defaultAwaitTime(2)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(States.READY)
+						.and()
+					.build();
+		plan.test();
+		context.close();
+	}
+
+	@Test
+	public void testMissingAppVersion() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
+		TestYarnCloudAppService yarnCloudAppService = new TestYarnCloudAppService();
+		TaskExecutor taskExecutor = context.getBean(TaskExecutor.class);
+		YarnCloudAppStateMachine ycasm = new YarnCloudAppStateMachine(yarnCloudAppService, taskExecutor);
+		StateMachine<States, Events> stateMachine = ycasm.buildStateMachine(false);
+
+		StateMachineTestPlan<States, Events> plan =
+				StateMachineTestPlanBuilder.<States, Events>builder()
+					.defaultAwaitTime(2)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(States.READY)
+						.and()
+					.step()
+						.sendEvent(Events.DEPLOY)
+						.expectStateChanged(3)
+						.expectStates(States.ERROR)
+						.and()
+					.build();
+		plan.test();
+		context.close();
+	}
+
+	@Test
+	public void testDeployShouldPushAndStart() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
+		TestYarnCloudAppService yarnCloudAppService = new TestYarnCloudAppService();
+		TaskExecutor taskExecutor = context.getBean(TaskExecutor.class);
+		YarnCloudAppStateMachine ycasm = new YarnCloudAppStateMachine(yarnCloudAppService, taskExecutor);
+		StateMachine<States, Events> stateMachine = ycasm.buildStateMachine(false);
+
+		Message<Events> message = MessageBuilder.withPayload(Events.DEPLOY)
+				.setHeader(YarnCloudAppStateMachine.HEADER_APP_VERSION, "fakeApp")
+				.setHeader(YarnCloudAppStateMachine.HEADER_CLUSTER_ID, "fakeClusterId")
+				.setHeader(YarnCloudAppStateMachine.HEADER_COUNT, 1)
+				.setHeader(YarnCloudAppStateMachine.HEADER_MODULE, "fakeModule")
+				.setHeader(YarnCloudAppStateMachine.HEADER_DEFINITION_PARAMETERS, new HashMap<Object, Object>())
+				.build();
+
+		StateMachineTestPlan<States, Events> plan =
+				StateMachineTestPlanBuilder.<States, Events>builder()
+					.defaultAwaitTime(100)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(States.READY)
+						.and()
+					.step()
+						.sendEvent(message)
+						.expectStateChanged(8)
+						.expectStates(States.READY)
+						.and()
+					.build();
+		plan.test();
+
+		assertThat(yarnCloudAppService.getApplicationsLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.getApplicationsCount, is(1));
+
+		assertThat(yarnCloudAppService.getInstancesLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.getInstancesCount, is(2));
+
+		assertThat(yarnCloudAppService.pushApplicationLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.pushApplicationCount.size(), is(1));
+		assertThat(yarnCloudAppService.pushApplicationCount.get(0).appVersion, is("fakeApp"));
+
+		assertThat(yarnCloudAppService.submitApplicationLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.submitApplicationCount.size(), is(1));
+		assertThat(yarnCloudAppService.submitApplicationCount.get(0).appVersion, is("fakeApp"));
+
+		assertThat(yarnCloudAppService.createClusterLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.createClusterCount.size(), is(1));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).yarnApplicationId, is("fakeApplicationId"));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).clusterId, is("fakeClusterId"));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).count, is(1));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).module, is("fakeModule"));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).definitionParameters.size(), is(0));
+
+		assertThat(yarnCloudAppService.startClusterLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.startClusterCount.size(), is(1));
+		assertThat(yarnCloudAppService.startClusterCount.get(0).yarnApplicationId, is("fakeApplicationId"));
+		assertThat(yarnCloudAppService.startClusterCount.get(0).clusterId, is("fakeClusterId"));
+
+		context.close();
+	}
+
+	@Test
+	public void testDeployAppAlreadyPushedNotStarted() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
+		TestYarnCloudAppService yarnCloudAppService = new TestYarnCloudAppService();
+		yarnCloudAppService.app = "fakeApp";
+		TaskExecutor taskExecutor = context.getBean(TaskExecutor.class);
+		YarnCloudAppStateMachine ycasm = new YarnCloudAppStateMachine(yarnCloudAppService, taskExecutor);
+		StateMachine<States, Events> stateMachine = ycasm.buildStateMachine(false);
+
+		Message<Events> message = MessageBuilder.withPayload(Events.DEPLOY)
+				.setHeader(YarnCloudAppStateMachine.HEADER_APP_VERSION, "fakeApp")
+				.setHeader(YarnCloudAppStateMachine.HEADER_CLUSTER_ID, "fakeClusterId")
+				.setHeader(YarnCloudAppStateMachine.HEADER_COUNT, 1)
+				.setHeader(YarnCloudAppStateMachine.HEADER_MODULE, "fakeModule")
+				.setHeader(YarnCloudAppStateMachine.HEADER_DEFINITION_PARAMETERS, new HashMap<Object, Object>())
+				.build();
+
+		StateMachineTestPlan<States, Events> plan =
+				StateMachineTestPlanBuilder.<States, Events>builder()
+					.defaultAwaitTime(2)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(States.READY)
+						.and()
+					.step()
+						.sendEvent(message)
+						.expectStateChanged(7)
+						.expectStates(States.READY)
+						.and()
+					.build();
+		plan.test();
+
+		assertThat(yarnCloudAppService.getApplicationsLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.getApplicationsCount, is(1));
+
+		assertThat(yarnCloudAppService.getInstancesLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.getInstancesCount, is(2));
+
+		assertThat(yarnCloudAppService.pushApplicationLatch.await(2, TimeUnit.SECONDS), is(false));
+		assertThat(yarnCloudAppService.pushApplicationCount.size(), is(0));
+
+		assertThat(yarnCloudAppService.submitApplicationLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.submitApplicationCount.size(), is(1));
+		assertThat(yarnCloudAppService.submitApplicationCount.get(0).appVersion, is("fakeApp"));
+
+		assertThat(yarnCloudAppService.createClusterLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.createClusterCount.size(), is(1));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).yarnApplicationId, is("fakeApplicationId"));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).clusterId, is("fakeClusterId"));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).count, is(1));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).module, is("fakeModule"));
+		assertThat(yarnCloudAppService.createClusterCount.get(0).definitionParameters.size(), is(0));
+
+		assertThat(yarnCloudAppService.startClusterLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(yarnCloudAppService.startClusterCount.size(), is(1));
+		assertThat(yarnCloudAppService.startClusterCount.get(0).yarnApplicationId, is("fakeApplicationId"));
+		assertThat(yarnCloudAppService.startClusterCount.get(0).clusterId, is("fakeClusterId"));
+
+		context.close();
+	}
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		TaskExecutor taskExecutor() {
+			ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+			taskExecutor.setCorePoolSize(1);
+			return taskExecutor;
+		}
+
+	}
+
+	private static class TestYarnCloudAppService implements YarnCloudAppService {
+
+		String app = null;
+		String instance = null;
+
+		volatile CountDownLatch getApplicationsLatch = new CountDownLatch(1);
+		volatile CountDownLatch getInstancesLatch = new CountDownLatch(2);
+		volatile CountDownLatch pushApplicationLatch = new CountDownLatch(1);
+		volatile CountDownLatch submitApplicationLatch = new CountDownLatch(1);
+		volatile CountDownLatch createClusterLatch = new CountDownLatch(1);
+		volatile CountDownLatch startClusterLatch = new CountDownLatch(1);
+		volatile CountDownLatch stopClusterLatch = new CountDownLatch(1);
+
+		int getApplicationsCount = 0;
+		int getInstancesCount = 0;
+		final ArrayList<Wrapper> pushApplicationCount = new ArrayList<Wrapper>();
+		final ArrayList<Wrapper> submitApplicationCount = new ArrayList<Wrapper>();
+		final ArrayList<Wrapper> createClusterCount = new ArrayList<Wrapper>();
+		final ArrayList<Wrapper> startClusterCount = new ArrayList<Wrapper>();
+		final ArrayList<Wrapper> stopClusterCount = new ArrayList<Wrapper>();
+
+		@Override
+		public Collection<CloudAppInfo> getApplications() {
+			ArrayList<CloudAppInfo> infos = new ArrayList<CloudAppInfo>();
+			if (app != null) {
+				infos.add(new CloudAppInfo(app));
+			}
+			getApplicationsCount++;
+			getApplicationsLatch.countDown();
+			return infos;
+		}
+
+		@Override
+		public Collection<CloudAppInstanceInfo> getInstances() {
+			ArrayList<CloudAppInstanceInfo> infos = new ArrayList<CloudAppInstanceInfo>();
+			if (instance != null) {
+				infos.add(new CloudAppInstanceInfo("fakeApplicationId", instance, "http://fakeAddress"));
+			}
+			getInstancesCount++;
+			getInstancesLatch.countDown();
+			return infos;
+		}
+
+		@Override
+		public void pushApplication(String appVersion) {
+			app = appVersion;
+			pushApplicationCount.add(new Wrapper(appVersion));
+			pushApplicationLatch.countDown();
+		}
+
+		@Override
+		public String submitApplication(String appVersion) {
+			instance = "spring-cloud-data-yarn-app_" + appVersion;
+			submitApplicationCount.add(new Wrapper(appVersion));
+			submitApplicationLatch.countDown();
+			return "fakeApplicationId";
+		}
+
+		@Override
+		public void createCluster(String yarnApplicationId, String clusterId, int count, String module,
+				Map<String, String> definitionParameters) {
+			createClusterCount.add(new Wrapper(yarnApplicationId, clusterId, count, module, definitionParameters));
+			createClusterLatch.countDown();
+		}
+
+		@Override
+		public void startCluster(String yarnApplicationId, String clusterId) {
+			startClusterCount.add(new Wrapper(yarnApplicationId, clusterId));
+			startClusterLatch.countDown();
+		}
+
+		@Override
+		public void stopCluster(String yarnApplicationId, String clusterId) {
+			stopClusterCount.add(new Wrapper(yarnApplicationId, clusterId));
+			stopClusterLatch.countDown();
+		}
+
+		@Override
+		public Map<String, String> getClustersStates() {
+			return null;
+		}
+
+		@Override
+		public Collection<String> getClusters(String yarnApplicationId) {
+			return null;
+		}
+
+		@Override
+		public void destroyCluster(String yarnApplicationId, String clusterId) {
+		}
+
+		static class Wrapper {
+			String appVersion;
+			String yarnApplicationId;
+			String clusterId;
+			int count;
+			String module;
+			Map<?, ?> definitionParameters;
+
+			public Wrapper(String appVersion) {
+				this.appVersion = appVersion;
+			}
+
+			public Wrapper(String yarnApplicationId, String clusterId) {
+				this.yarnApplicationId = yarnApplicationId;
+				this.clusterId = clusterId;
+			}
+
+			public Wrapper(String yarnApplicationId, String clusterId, int count, String module,
+					Map<?, ?> definitionParameters) {
+				this.yarnApplicationId = yarnApplicationId;
+				this.clusterId = clusterId;
+				this.count = count;
+				this.module = module;
+				this.definitionParameters = definitionParameters;
+			}
+
+		}
+	}
+
+}

--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/test/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachineTests.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/test/java/org/springframework/cloud/data/module/deployer/yarn/YarnCloudAppStateMachineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,8 +37,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.listener.StateMachineListenerAdapter;
-import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.test.StateMachineTestPlan;
 import org.springframework.statemachine.test.StateMachineTestPlanBuilder;
 

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-yarn-boot</artifactId>
-			<version>2.3.0.M1</version>
+			<version>2.3.0.M2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>javax.servlet</groupId>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/AppmasterApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/AppmasterApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/CloudDataAppmaster.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/CloudDataAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/CloudDataAppmaster.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/java/org/springframework/cloud/data/yarn/appmaster/CloudDataAppmaster.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.data.yarn.appmaster;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -43,11 +44,18 @@ public class CloudDataAppmaster extends ManagedContainerClusterAppmaster {
 		ArrayList<String> list = new ArrayList<String>(commands);
 		Map<String, Object> extraProperties = cluster.getExtraProperties();
 
-		log.debug("onContainerLaunchCommands extraProperties=" + extraProperties);
+		log.info("onContainerLaunchCommands extraProperties=" + extraProperties);
 
-		if (extraProperties != null && extraProperties.containsKey("containerModules")) {
-			String value = "containerModules=" + cluster.getExtraProperties().get("containerModules");
-			list.add(Math.max(list.size() - 2, 0), value);
+		if (extraProperties != null) {
+			if (extraProperties.containsKey("containerModules")) {
+				String value = "containerModules=" + cluster.getExtraProperties().get("containerModules");
+				list.add(Math.max(list.size() - 2, 0), value);
+			}
+			for (Entry<String, Object> entry : extraProperties.entrySet()) {
+				if (entry.getKey().startsWith("containerArg")) {
+					list.add(Math.max(list.size() - 2, 0), entry.getValue().toString());
+				}
+			}
 		}
 		list.add(1, "-Dserver.port=0");
 		return list;

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/pom.xml
@@ -19,12 +19,12 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-yarn-boot</artifactId>
-			<version>2.3.0.M1</version>
+			<version>2.3.0.M2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-yarn-boot-cli</artifactId>
-			<version>2.3.0.M1</version>
+			<version>2.3.0.M2</version>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/java/org/springframework/cloud/data/yarn/client/ClientApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/java/org/springframework/cloud/data/yarn/client/ClientApplication.java
@@ -30,6 +30,7 @@ import org.springframework.yarn.boot.cli.YarnClustersInfoCommand;
 import org.springframework.yarn.boot.cli.YarnKillCommand;
 import org.springframework.yarn.boot.cli.YarnPushCommand;
 import org.springframework.yarn.boot.cli.YarnPushedCommand;
+import org.springframework.yarn.boot.cli.YarnShutdownCommand;
 import org.springframework.yarn.boot.cli.YarnSubmitCommand;
 import org.springframework.yarn.boot.cli.YarnSubmittedCommand;
 import org.springframework.yarn.boot.cli.YarnSubmittedCommand.SubmittedOptionHandler;
@@ -44,9 +45,7 @@ public class ClientApplication extends AbstractCli {
 		commands.add(new YarnSubmitCommand());
 		commands.add(new YarnSubmittedCommand(new SubmittedOptionHandler("CLOUDDATA")));
 		commands.add(new YarnKillCommand());
-		// disable due to boot #3724 which broke
-		// container registrar
-		//commands.add(new YarnShutdownCommand());
+		commands.add(new YarnShutdownCommand());
 		commands.add(new YarnClustersInfoCommand());
 		commands.add(new YarnClusterInfoCommand());
 		commands.add(new YarnClusterCreateCommand());

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-yarn-boot</artifactId>
-			<version>2.3.0.M1</version>
+			<version>2.3.0.M2</version>
 			<exclusions>
 <!--
 				<exclusion>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/java/org/springframework/cloud/data/yarn/container/ContainerApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/java/org/springframework/cloud/data/yarn/container/ContainerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/java/org/springframework/cloud/data/yarn/container/ContainerApplication.java
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/java/org/springframework/cloud/data/yarn/container/ContainerApplication.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.data.yarn.container;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
@@ -57,15 +58,26 @@ public class ContainerApplication extends YarnContainerSupport {
 	@OnContainerStart
 	public Future<Boolean> runModule(@YarnParameters Properties properties, @YarnParameter("containerModules") String module) {
 		log.info("runModule module=" + module);
-		log.info("runModule properies=" + properties);
+		log.info("runModule properties=" + properties);
 		log.info("moduleLauncher=" + moduleLauncher);
+
+		Map<String, String> args = new HashMap<String, String>();
+
+		for (Entry<Object, Object> entry : properties.entrySet()) {
+			String key = entry.getKey().toString();
+			String value = entry.getValue().toString();
+			if (!key.startsWith("containerModules")) {
+				args.put(key, value);
+			}
+		}
+
+		log.info("Passing args to moduleLauncher: " + args);
 
 		// we should somehow get status back from module
 		// launcher when it fails or finishes to set future
 		// indicating we're done. Naturally exception will
 		// terminate execution chain and container will exit.
 		SettableListenableFuture<Boolean> status = new SettableListenableFuture<Boolean>();
-		Map<String, String> args = new HashMap<>(); // TODO
 		moduleLauncher.launch(Arrays.asList(new ModuleLaunchRequest(module, args)));
 		return status;
 	}


### PR DESCRIPTION
Fix yarn profile
- AdminApplication/AdminConfiguration were changed to rely on component scan which did work with yarn profile because YarnConfiguration did have @Configuration and its bean 'yarnConfiguration' was overriden from spring-yarn autoconfiguration. This didn't cause trouble when YarnConfiguration were imported because bean name were then org.springframework.cloud.data.admin.config.YarnConfiguration. Component scan is creating different bean names, 'yarnConfiguration' in this case.
- Disabling spring yarn auto-config, classes are needed in future PR's so not removing deps.
- Add @Configuration to YarnConfiguration for scan to work.
- Add tests for default/yarn profiles.

XD-3400 XD-3401 XD-3402
- Update to shdp 2.3.0.M2
- Add statemachine to control deployment flow into yarn
- Support passing module props from stream into module ran by yarn
- Support automatically pushing and starting yarn app instance
- Update README to reflect these changes