### PR TITLE
local deployer uses server.port if provided

### DIFF
--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-local/src/main/java/org/springframework/cloud/data/module/deployer/local/LocalModuleDeployer.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-local/src/main/java/org/springframework/cloud/data/module/deployer/local/LocalModuleDeployer.java
@@ -69,7 +69,14 @@ public class LocalModuleDeployer implements ModuleDeployer {
 		args.putAll(request.getDeploymentProperties());
 
 		logger.info("deploying module: {}", module);
-		int port = SocketUtils.findAvailableTcpPort(8080);
+		int port;
+		if (args.containsKey("server.port")) {
+			port = Integer.parseInt(args.get("server.port"));
+		}
+		else {
+			port = SocketUtils.findAvailableTcpPort(8080);
+			args.put("server.port", String.valueOf(port));
+		}
 		URL moduleUrl;
 		try {
 			moduleUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(), port, "");
@@ -77,7 +84,6 @@ public class LocalModuleDeployer implements ModuleDeployer {
 		catch (Exception e) {
 			throw new IllegalStateException("failed to determine URL for module: " + module, e);
 		}
-		args.put("server.port", String.valueOf(port));
 		args.put("endpoints.shutdown.enabled", "true");
 
 		ModuleLaunchRequest moduleLaunchRequest = new ModuleLaunchRequest(module, args);


### PR DESCRIPTION
If the 'server.port' for a module is provided via deployment properties,
the LocalModuleDeployer will now attempt to use that port rather than allocating
one. This allows the use of an explicitly provided port for the 'http' source, e.g.:
- stream deploy example --properties "module.http.server.port=9000"