### PR TITLE
XD-3461 Remove yarn related hardcoded file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ hdfs dfs -rm -R /app/app
 4\. start `spring-cloud-data-admin` with `yarn` profile
 
 ```
-$ java -Dspring.profiles.active=yarn -jar spring-cloud-data-admin/target/spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar
+$ java -Dspring.profiles.active=yarn -Dclouddata.yarn.app.appmaster.path=spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/target -Dclouddata.yarn.app.container.path=spring-cloud-data-yarn/spring-cloud-data-yarn-container/target -jar spring-cloud-data-admin/target/spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar
 ```
 
 5\. start `spring-cloud-data-shell`
@@ -143,3 +143,4 @@ $ shutdown -a application_1439803106751_0088
 shutdown requested
 ```
 
+Properties `clouddata.yarn.app.appmaster.path` and `clouddata.yarn.app.container.path` can be used with both `spring-cloud-data-admin` and `and spring-cloud-data-yarn-client` to define directory for `appmaster` and `container` jars. Values for those default to `.` which then assumes all needed jars are in a same working directory.

--- a/spring-cloud-data-admin/pom.xml
+++ b/spring-cloud-data-admin/pom.xml
@@ -108,7 +108,20 @@
 		</dependency>
 	</dependencies>
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>application.yml</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/spring-cloud-data-admin/src/main/resources/application.yml
+++ b/spring-cloud-data-admin/src/main/resources/application.yml
@@ -13,13 +13,12 @@ spring:
     appType: CLOUDDATA
     appName: spring-cloud-data-yarn-app
     applicationBaseDir: /app/
-    applicationDir: /app/spring-cloud-data-yarn-app/
     client:
       clientClass: org.springframework.yarn.client.DefaultApplicationYarnClient
       files:
-        - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/target/spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar"
-        - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-container/target/spring-cloud-data-yarn-container-1.0.0.BUILD-SNAPSHOT.jar"
+        - "file:${clouddata.yarn.app.appmaster.path:.}/spring-cloud-data-yarn-appmaster-@project.version@.jar"
+        - "file:${clouddata.yarn.app.container.path:.}/spring-cloud-data-yarn-container-@project.version@.jar"
       launchcontext:
-        archiveFile: spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar
+        archiveFile: spring-cloud-data-yarn-appmaster-@project.version@.jar
       resource:
         memory: 1g

--- a/spring-cloud-data-yarn/pom.xml
+++ b/spring-cloud-data-yarn/pom.xml
@@ -20,24 +20,4 @@
 		<module>spring-cloud-data-yarn-client</module>
 	</modules>
 
-<!--
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-yarn-boot</artifactId>
-			<version>2.3.0.M1</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-	</dependencies>
--->
-
 </project>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/pom.xml
@@ -52,7 +52,20 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>application.yml</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/resources/application.yml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/src/main/resources/application.yml
@@ -1,33 +1,33 @@
 server:
-    port: 0
+  port: 0
 endpoints:
-    shutdown:
-        enabled: true
+  shutdown:
+    enabled: true
 spring:
-    hadoop:
-        fsUri: hdfs://localhost:8020
-        resourceManagerHost: localhost
-    yarn:
-        appType: BOOT
-        appName: spring-cloud-data-yarn-app
-        applicationBaseDir: /app/
-        applicationDir: /app/spring-cloud-data-yarn-app/
-        appmaster:
-            appmasterClass: org.springframework.cloud.data.yarn.appmaster.CloudDataAppmaster
-            keepContextAlive: true
-            containercluster:
-                enabled: true
-                clusters:
-                    module-template:
-                        resource:
-                            priority: 10
-                            memory: 64
-                            virtualCores: 1
-                        launchcontext:
-                            locality: false
-                            archiveFile: spring-cloud-data-yarn-container-1.0.0.BUILD-SNAPSHOT.jar
-        endpoints:
-            containercluster:
-                enabled: true
-            containerregister:
-                enabled: false
+  hadoop:
+    fsUri: hdfs://localhost:8020
+    resourceManagerHost: localhost
+  yarn:
+    appType: BOOT
+    appName: spring-cloud-data-yarn-app
+    applicationBaseDir: /app/
+    applicationDir: /app/spring-cloud-data-yarn-app/
+    appmaster:
+      appmasterClass: org.springframework.cloud.data.yarn.appmaster.CloudDataAppmaster
+      keepContextAlive: true
+      containercluster:
+        enabled: true
+        clusters:
+          module-template:
+            resource:
+              priority: 10
+              memory: 64
+              virtualCores: 1
+            launchcontext:
+              locality: false
+              archiveFile: spring-cloud-data-yarn-container-@project.version@.jar
+    endpoints:
+      containercluster:
+        enabled: true
+      containerregister:
+        enabled: false

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/pom.xml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/pom.xml
@@ -29,7 +29,20 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>application.yml</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/application.yml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/application.yml
@@ -1,20 +1,23 @@
+logging:
+  level:
+    org.springframework: WARN
+    org.apache.hadoop: OFF
 spring:
-    main:
-        show_banner: false
-    hadoop:
-        fsUri: hdfs://localhost:8020
-        resourceManagerHost: localhost
-    yarn:
-        appType: CLOUDDATA
-        appName: spring-cloud-data-yarn-app
-        applicationBaseDir: /app/
-        applicationDir: /app/spring-cloud-data-yarn-app/
-        client:
-            clientClass: org.springframework.yarn.client.DefaultApplicationYarnClient
-            files:
-              - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-appmaster/target/spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar"
-              - "file:spring-cloud-data-yarn/spring-cloud-data-yarn-container/target/spring-cloud-data-yarn-container-1.0.0.BUILD-SNAPSHOT.jar"
-            launchcontext:
-                archiveFile: spring-cloud-data-yarn-appmaster-1.0.0.BUILD-SNAPSHOT.jar
-            resource:
-                memory: 1g
+  main:
+    show_banner: false
+  hadoop:
+    fsUri: hdfs://localhost:8020
+    resourceManagerHost: localhost
+  yarn:
+    appType: CLOUDDATA
+    appName: spring-cloud-data-yarn-app
+    applicationBaseDir: /app/
+    client:
+      clientClass: org.springframework.yarn.client.DefaultApplicationYarnClient
+      files:
+        - "file:${clouddata.yarn.app.appmaster.path:.}/spring-cloud-data-yarn-appmaster-@project.version@.jar"
+        - "file:${clouddata.yarn.app.container.path:.}/spring-cloud-data-yarn-container-@project.version@.jar"
+      launchcontext:
+        archiveFile: spring-cloud-data-yarn-appmaster-@project.version@.jar
+      resource:
+        memory: 1g

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/log4j.properties
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-client/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log4j.rootCategory=WARN, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d %p [%C{1}] - %m%n
-
-log4j.category.org.apache.hadoop=OFF

--- a/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/resources/application.yml
+++ b/spring-cloud-data-yarn/spring-cloud-data-yarn-container/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 server:
-    port: 0
+  port: 0
 endpoints:
-    shutdown:
-        enabled: false
+  shutdown:
+    enabled: false
 spring:
-    hadoop:
-        fsUri: hdfs://localhost:8020
-        resourceManagerHost: localhost
+  hadoop:
+    fsUri: hdfs://localhost:8020
+    resourceManagerHost: localhost
 


### PR DESCRIPTION
NOTE: check README for changes howto start admin and client

- Modify build to replace placeholder `@project.version@` with
  a proper version which is needed for other than snapshots.
- Generic polish of yml files
- Moved logging config into application.yml for client. Somehow
  this boot logging got broken again without doing any changes.
- Introduce `clouddata.yarn.app.appmaster.path` and
  `clouddata.yarn.app.container.path` which defaults to `.` and can be
  used to define actual locations where appmaster and container jars
  will be found. Defaults to `.` because it is assumed that with an actual
  release all needed jars are in a same location.
- Updated README