### PR TITLE
Yarn SPI: Fixed NPE when module is not deployed

### DIFF
--- a/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
+++ b/spring-cloud-data-module-deployers/spring-cloud-data-module-deployer-yarn/src/main/java/org/springframework/cloud/data/module/deployer/yarn/YarnModuleDeployer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.data.module.deployer.yarn;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -102,7 +103,14 @@ public class YarnModuleDeployer implements ModuleDeployer {
 
 	@Override
 	public ModuleStatus status(ModuleDeploymentId id) {
-		return status().get(id);
+		ModuleStatus status = status().get(id);
+		if (status == null) {
+			status = ModuleStatus.of(id)
+					.with(new YarnModuleInstanceStatus(id.toString(), false,
+							Collections.<String, String>emptyMap()))
+					.build();
+		}
+		return status;
 	}
 
 	@Override


### PR DESCRIPTION
When performing a `stream list` for a stream that is not deployed, the Yarn SPI will throw the following exception:

```
java.lang.NullPointerException: null
	at org.springframework.cloud.data.admin.controller.StreamController.calculateStreamState(StreamController.java:261) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at org.springframework.cloud.data.admin.controller.StreamController.access$000(StreamController.java:69) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at org.springframework.cloud.data.admin.controller.StreamController$Assembler.instantiateResource(StreamController.java:302) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at org.springframework.cloud.data.admin.controller.StreamController$Assembler.instantiateResource(StreamController.java:288) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at org.springframework.hateoas.mvc.ResourceAssemblerSupport.createResourceWithId(ResourceAssemblerSupport.java:89) ~[spring-hateoas-0.19.0.RELEASE.jar!/:na]
	at org.springframework.hateoas.mvc.ResourceAssemblerSupport.createResourceWithId(ResourceAssemblerSupport.java:81) ~[spring-hateoas-0.19.0.RELEASE.jar!/:na]
	at org.springframework.cloud.data.admin.controller.StreamController$Assembler.toResource(StreamController.java:296) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at org.springframework.cloud.data.admin.controller.StreamController$Assembler.toResource(StreamController.java:288) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at org.springframework.data.web.PagedResourcesAssembler.createResource(PagedResourcesAssembler.java:137) ~[spring-data-commons-1.9.1.RELEASE.jar!/:na]
	at org.springframework.data.web.PagedResourcesAssembler.toResource(PagedResourcesAssembler.java:96) ~[spring-data-commons-1.9.1.RELEASE.jar!/:na]
	at org.springframework.cloud.data.admin.controller.StreamController.list(StreamController.java:127) ~[spring-cloud-data-admin-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_31]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_31]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_31]
	at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0_31]
```
This fix ensures that a non-null status is returned for a module that is not deployed in Yarn.